### PR TITLE
Account refactor

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,4 +1,4 @@
+import '@storybook/addon-knobs/register';
 import "@storybook/addon-actions/register";
 import "@storybook/addon-links/register";
-import '@storybook/addon-knobs/register';
 import '@storybook/addon-viewport/register';

--- a/src/components/Account.vue
+++ b/src/components/Account.vue
@@ -1,23 +1,26 @@
 <template>
-    <div class="account" :class="{ 'editable': editable }">
+    <div class="account" :class="[{ editable }, layout]">
         <div class="identicon-and-label">
-            <Identicon :address="address"/>
-
-            <div v-if="!editable" class="label">
-                <div>{{ label }}</div>
+            <div v-if="showImage" class="identicon">
+                <img class="account-image" :src="image" @error="showImage = false">
+                <div class="outline"></div>
             </div>
-            <div v-else class="label">
+            <Identicon v-else :address="address"/>
+
+            <div v-if="!editable" class="label">{{ label }}</div>
+            <div v-else class="label editable">
                 <LabelInput :value="label" @changed="changed" ref="label"/>
             </div>
+
+            <div v-if="layout === 'column' && walletLabel" class="nq-label wallet-label">{{ walletLabel }}</div>
         </div>
 
-        <div class="balance" v-if="balance || balance === 0"><Amount :amount="balance" :decimals="2"/></div>
-        <!-- <div class="balance balance-loading" v-if="!balance && balance !== 0"></div> -->
+        <Amount v-if="balance || balance === 0" class="balance" :amount="balance" :decimals="2" />
     </div>
 </template>
 
 <script lang="ts">
-    import { Component, Prop, Emit, Vue } from 'vue-property-decorator';
+    import { Component, Prop, Emit, Watch, Vue } from 'vue-property-decorator';
     import Identicon from './Identicon.vue';
     import Amount from './Amount.vue';
     import LabelInput from './LabelInput.vue';
@@ -25,9 +28,18 @@
     @Component({components: {Amount, Identicon, LabelInput}})
     export default class Account extends Vue {
         @Prop(String) public address!: string;
+        @Prop(String) public image?: string;
         @Prop(String) public label!: string;
-        @Prop(Number) public balance!: number;
-        @Prop(Boolean) private editable?: boolean;
+        @Prop(String) public walletLabel?: string;
+        @Prop(Number) public balance?: number;
+        @Prop(Boolean) public editable?: boolean;
+        @Prop({
+            type: String,
+            default: 'row',
+            validator: (layout) => ['row', 'column'].indexOf(layout) !== -1,
+        }) public layout!: string;
+
+        private showImage: boolean = !!this.image;
 
         public focus() {
             if (this.editable) {
@@ -38,55 +50,145 @@
         @Emit()
         // tslint:disable-next-line no-empty
         private changed(label: string) {}
+
+        @Watch('image', { immediate: true })
+        private onImageChange() {
+            this.showImage = !!this.image;
+
+            // load clip path if not done so yet
+            if (!this.showImage || document.getElementById('nimiq-hexagon-clip')) return;
+            /* tslint:disable max-line-length */
+            document.body.insertAdjacentHTML('beforeend', `
+                <svg width="0" height="0" viewBox="0 0 146 146">
+                    <defs>
+                        <clipPath id="nimiq-hexagon-clip" clipPathUnits="objectBoundingBox">
+                            <path d="M.302.055A.106.106 0 0 0 .21.108l-.196.34a.106.106 0 0 0 0 .105l.196.34a.106.106 0 0 0 .092.052h.392c.038 0 .073-.02.092-.053l.196-.34a.106.106 0 0 0 0-.105L.786.107A.106.106 0 0 0 .694.056z">
+                            </path>
+                        </clipPath>
+                    </defs>
+                </svg>
+            `);
+            /* tslint:enable max-line-length */
+        }
     }
 </script>
 
 <style scoped>
     .account {
-        width: 100%;
         display: flex;
-        flex-direction: row;
         align-items: center;
         justify-content: space-between;
         padding: 1.75rem 2rem;
         box-sizing: border-box;
         flex-shrink: 0;
         font-size: 2rem;
-        line-height: 1.25;
+        line-height: 1.2;
+    }
+
+    .account.row {
+        width: 100%;
+        flex-direction: row;
+    }
+
+    .account.column {
+        flex-direction: column;
     }
 
     .identicon-and-label {
         display: flex;
-        flex-direction: row;
         align-items: center;
+    }
+
+    .row .identicon-and-label {
+        flex-direction: row;
         overflow: hidden;
         min-width: 5.625rem;
     }
 
+    .column .identicon-and-label {
+        flex-direction: column;
+    }
+
     .identicon {
+        flex-shrink: 0;
+        position: relative;
+    }
+
+    .row .identicon {
         width: 5.625rem;
         height: 5.625rem;
-        flex-shrink: 0;
         margin-right: 1.5rem;
     }
 
-    .label {
-        white-space: nowrap;
-        font-weight: 600;
-        overflow: hidden;
+    .column .identicon {
+        width: 9rem;
+        height: 9rem;
+        margin-bottom: 1.5rem;
     }
 
-    .label div {
-        opacity: 0.7;
+    .identicon .account-image {
+        width: 100%;
+        height: 100%;
+        clip-path: url(#nimiq-hexagon-clip);
+    }
+
+    .identicon .outline {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        background-repeat: no-repeat;
+        background-position: 0 center;
+        background-size: contain;
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="146" height="146"><path d="M113.8 16.2l28.7 49.6c2.5 4.5 2.5 10 0 14.4l-28.7 49.6a14.4 14.4 0 0 1-12.5 7.2H44.1c-5.2 0-10-2.7-12.5-7.2L2.9 80.2C.4 75.7.4 70.2 3 65.8l28.7-49.6C34.2 11.7 38.9 9 44 9h57.2c5.2 0 10 2.7 12.5 7.2z" clip-rule="evenodd" stroke="%231f2348" stroke-width="2" opacity=".2"/></svg>');
+    }
+
+    .label,
+    .wallet-label {
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .wallet-label {
+        margin-bottom: 0;
+    }
+
+    .row .label:not(.editable) {
+        opacity: 0.7;
         padding-left: 1rem;
+    }
+
+    .row .label,
+    .row .wallet-label {
+        white-space: nowrap;
+        font-weight: 600;
+    }
+
+    .column .label,
+    .column .wallet-label {
+        max-width: 16.5rem;
+        text-align: center;
+        line-height: 1.5;
+        /* TODO implement multi line ellipsis */
+        max-height: calc(2 * 1em * 1.5); /* #lines * font-size * line-height */
+    }
+
+    .column .label-input >>> input {
+        text-align: center;
     }
 
     .balance {
         flex-shrink: 0;
-        font-weight: bold;
+    }
+
+    .row .balance {
         margin-left: 2rem;
+        font-weight: bold;
         opacity: 0.7;
+    }
+
+    .column .balance {
+        margin-top: 1.5rem;
     }
 </style>

--- a/src/components/AccountDetails.vue
+++ b/src/components/AccountDetails.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="account-info">
+    <div class="account-details">
         <a href="javascript:void(0)" class="nq-icon cancel-circle" @click="close"></a>
         <Account layout="column" :address="address" :image="image" :label="label !== address ? label : ''"
              :walletLabel="walletLabel" :balance="balance"></Account>
@@ -14,7 +14,7 @@ import Amount from './Amount.vue';
 import AddressDisplay from './AddressDisplay.vue';
 
 @Component({components: {Account, Amount, AddressDisplay}})
-export default class AccountInfo extends Vue {
+export default class AccountDetails extends Vue {
     @Prop(String) private address!: string;
     @Prop(String) private image?: string;
     @Prop(String) private label?: string;
@@ -44,7 +44,7 @@ export default class AccountInfo extends Vue {
     }
     /* END Nimiq Style */
 
-    .account-info {
+    .account-details {
         display: flex;
         flex-direction: column;
         justify-content: center;

--- a/src/components/AccountInfo.vue
+++ b/src/components/AccountInfo.vue
@@ -1,49 +1,25 @@
 <template>
     <div class="account-info">
         <a href="javascript:void(0)" class="nq-icon cancel-circle" @click="close"></a>
-        <div v-if="shopLogoUrl && showShopLogo" class="shop-logo">
-            <div class="cover"></div>
-            <img class="logo" :src="shopLogoUrl" @error="showShopLogo = false">
-        </div>
-        <Identicon v-else :address="address"/>
-        <div v-if="label || originDomain || walletLabel" class="labels">
-            <div v-if="label || originDomain" class="label">{{ label || originDomain }}</div>
-            <div v-if="walletLabel" class="wallet-label nq-label">{{ walletLabel }}</div>
-        </div>
-        <Amount v-if="balance !== undefined" :amount="balance" :decimals="2"/>
+        <Account layout="column" :address="address" :image="image" :label="label !== address ? label : ''"
+             :walletLabel="walletLabel" :balance="balance"></Account>
         <AddressDisplay :address="address"/>
-
-        <svg width="0" height="0" viewBox="0 0 146.0 146.0">
-            <defs>
-                <clipPath id="nimiq-rounded-hexagon" clipPathUnits="objectBoundingBox" transform="scale(0.006849315068 0.006849315068)">
-                    <path d="M 44.060547,8 C 38.556215,8 33.46353,10.940381 30.707031,15.708984 L 2.0605469,65.291016 c -2.74702868,4.768904 -2.74702868,10.649064 0,15.417968 L 30.701172,130.29102 C 33.449256,135.06056 38.546656,138 44.054688,138 H 101.3418 c 5.50812,0 10.60514,-2.93949 13.35351,-7.70898 v -0.002 l 28.64063,-49.578122 v -0.002 c 2.75485,-4.768341 2.75485,-10.649627 0,-15.417968 v -0.002 L 114.69531,15.710938 C 111.94712,10.940605 106.85041,8 101.3418,8 Z">
-                    </path>
-                </clipPath>
-            </defs>
-        </svg>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Emit, Vue } from 'vue-property-decorator';
-import Identicon from './Identicon.vue';
+import Account from './Account.vue';
 import Amount from './Amount.vue';
 import AddressDisplay from './AddressDisplay.vue';
 
-@Component({components: {Identicon, Amount, AddressDisplay}})
+@Component({components: {Account, Amount, AddressDisplay}})
 export default class AccountInfo extends Vue {
     @Prop(String) private address!: string;
-    @Prop(String) private shopLogoUrl?: string;
+    @Prop(String) private image?: string;
     @Prop(String) private label?: string;
-    @Prop(String) private origin?: string;
     @Prop(String) private walletLabel?: string;
     @Prop(Number) private balance?: number;
-
-    private showShopLogo: boolean = true;
-
-    private get originDomain() {
-        return this.origin ? this.origin.split('://')[1] : '';
-    }
 
     @Emit()
     // tslint:disable-next-line no-empty
@@ -76,6 +52,7 @@ export default class AccountInfo extends Vue {
         flex-grow: 1;
         position: relative;
         background: rgba(255, 255, 255, 0.95);
+        padding: 4rem;
         border-radius: 1rem;
         width: 100%;
         height: 100%;
@@ -116,61 +93,38 @@ export default class AccountInfo extends Vue {
         outline: none;
     }
 
-    .identicon,
-    .shop-logo {
-        width: 18.25rem;
-        height: 18.25rem;
+    .account {
+        padding: 0;
+    }
+
+    .account >>> .identicon {
+        width: 18rem;
+        height: 18rem;
         margin-bottom: 3rem;
     }
 
-    .shop-logo {
-        position: relative;
-    }
-
-    .shop-logo img {
-        width: 100%;
-        height: 100%;
-        clip-path: url(#nimiq-rounded-hexagon);
-    }
-
-    .shop-logo .cover {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        background-repeat: no-repeat;
-        background-position: 0 center;
-        background-size: 100%;
-        background-size: contain;
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="146" height="146"><path d="M113.829 16.20974L142.47 65.7903c2.578 4.461 2.578 9.9584 0 14.4194L113.829 129.79c-2.57 4.461-7.335 7.21-12.488 7.21H44.0555c-5.1529 0-9.918-2.749-12.4877-7.21L2.92725 80.2097c-2.56966698-4.461-2.56966698-9.9584 0-14.4194L31.5723 16.20974C34.151 11.74872 38.9116 9 44.06 9h57.281c5.153 0 9.918 2.74872 12.488 7.20974z" clip-rule="evenodd" stroke="%231f2348" stroke-width="2" opacity=".2"/></svg>');
-        z-index: 1;
-    }
-
-    .labels {
-        text-align: center;
-    }
-
-    .label {
+    .account >>> .label {
         font-size: 3rem;
         font-weight: 600;
-        line-height: 1;
+        opacity: 1;
     }
 
-    .label + .wallet-label {
-        margin-top: 1.5rem;
+    .account >>> .wallet-label {
+        margin-top: .5rem;
     }
 
-    .amount {
+    .account >>> .label,
+    .account >>> .wallet-label {
+        max-width: unset;
+        max-height: unset;
+    }
+
+    .account >>> .balance {
         font-size: 3rem;
-        margin-top: 2rem;
+        margin-top: 3rem;
     }
 
     .address-display {
         margin-top: 7rem;
-    }
-
-    .labels + .address-display {
-        margin-top: 9rem;
     }
 </style>

--- a/src/components/Amount.vue
+++ b/src/components/Amount.vue
@@ -1,6 +1,6 @@
 <template>
-    <span :class="showApprox && isApprox(amount) ? 'amount approx' : 'amount'">
-        {{ amountToString() }}
+    <span class="amount" :class="{ approx: showApprox && isApprox }">
+        {{ formattedAmount }}
         <span class="nim">NIM</span>
     </span>
 </template>
@@ -14,7 +14,7 @@
         @Prop({type: Number, default: 2, validator(value) { return value >= 0 && value <= 5; }}) public decimals!: number;
         @Prop({type: Boolean, default: false}) public showApprox!: boolean;
 
-        private amountToString() {
+        private get formattedAmount() {
             const roundingFactor = Math.pow(10, this.decimals);
             const value = Math.floor((this.amount / 1e5) * roundingFactor) / roundingFactor;
             const result = value.toFixed(this.decimals);
@@ -24,25 +24,10 @@
             return result.replace(regexp, '$1\u2009');
         }
 
-        private isApprox() {
+        private get isApprox() {
             const roundedNum = Number.parseFloat((this.amount / 1e5).toFixed(this.decimals));
             return roundedNum.toFixed(5) !== (this.amount / 1e5).toFixed(5);
         }
-
-        // private formatNumber(value: number, maxDecimals: number = 5, minDecimals: number = 2): string {
-        //     const roundingFactor = 10 ** maxDecimals;
-        //     value = Math.floor(value * roundingFactor) / roundingFactor;
-
-        //     const result = parseFloat(value.toFixed(minDecimals)) === value
-        //         ? value.toFixed(minDecimals)
-        //         : value.toString();
-
-        //     if (Math.abs(value) < 10000) return result;
-
-        //     // Add thin spaces (U+202F) every 3 digits. Stop at the decimal separator if there is one.
-        //     const regexp = minDecimals > 0 ? /(\d)(?=(\d{3})+\.)/g : /(\d)(?=(\d{3})+$)/g;
-        //     return result.replace(regexp, '$1\u202F');
-        // }
     }
 </script>
 

--- a/src/components/PaymentInfoLine.vue
+++ b/src/components/PaymentInfoLine.vue
@@ -1,16 +1,11 @@
 <template>
     <div class="info-line">
-        <Amount :amount="this.amount + this.fee" :decimals="decimals"/>
+        <Amount :amount="amount + fee" :decimals="decimals" />
         <div class="arrow-runway">
             <i class="nq-icon arrow-right"></i>
         </div>
         <a href="javascript:void(0)" class="description" @click="merchantInfoClicked">
-            <div v-if="shopLogoUrl && showShopLogo" class="shop-logo">
-                <div class="cover"></div>
-                <img class="logo" :src="shopLogoUrl" @error="showShopLogo = false">
-            </div>
-            <Identicon v-else :address="address"/>
-            <span class="origin">{{ originDomain }}</span>
+            <Account :address="address" :image="shopLogoUrl" :label="originDomain" />
             <i class="nq-icon info-circle"></i>
         </a>
     </div>
@@ -19,22 +14,20 @@
 <script lang="ts">
 import {Component, Prop, Emit, Vue} from 'vue-property-decorator';
 import Amount from './Amount.vue';
-import Identicon from './Identicon.vue';
+import Account from './Account.vue';
 
-@Component({components: {Amount, Identicon}})
+@Component({components: {Amount, Account}})
 export default class PaymentInfoLine extends Vue {
 
     private get originDomain() {
         return this.origin.split('://')[1];
     }
-    @Prop({type: Number, default: 2, validator(value) { return value >= 0 && value <= 5; }}) public decimals!: number;
+    @Prop({type: Number, default: 2}) public decimals!: number;
     @Prop(Number) private amount!: number;
     @Prop(Number) private fee!: number;
     @Prop(String) private origin!: string;
     @Prop(String) private address?: string;
     @Prop(String) private shopLogoUrl?: string;
-
-    private showShopLogo: boolean = true;
 
     @Emit()
     // tslint:disable-next-line no-empty
@@ -119,8 +112,12 @@ export default class PaymentInfoLine extends Vue {
         text-decoration: none;
     }
 
-    .shop-logo,
-    .identicon {
+    .account {
+        padding: 0;
+        width: auto !important;
+    }
+
+    .account >>> .identicon {
         min-width: unset;
         width: 3.375rem;
         height: 3.375rem;
@@ -129,31 +126,11 @@ export default class PaymentInfoLine extends Vue {
         margin-right: 1rem;
     }
 
-    .shop-logo {
-        position: relative;
-    }
-
-    .shop-logo img {
-        width: 100%;
-        height: 100%;
-    }
-
-    .shop-logo .cover {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        background-repeat: no-repeat;
-        background-position: center;
-        background-size: 100%;
-        background-size: contain;
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 27 27"><path fill="%231F2348" opacity=".2" d="M19.1,3c0.4,0,0.9,0.2,1.1,0.6l5.6,9.8c0.2,0.4,0.2,0.9,0,1.3l-5.6,9.8C20,24.8,19.6,25,19.1,25H7.9 c-0.4,0-0.9-0.2-1.1-0.6l-5.6-9.7c-0.2-0.4-0.2-0.9,0-1.3l5.6-9.8C7,3.2,7.4,3,7.9,3H19.1 M19.1,2H7.9C7.1,2,6.3,2.4,5.9,3.1 l-5.6,9.8c-0.4,0.7-0.4,1.6,0,2.2l5.6,9.8C6.3,25.6,7.1,26,7.9,26h11.3c0.8,0,1.5-0.4,1.9-1.1l5.6-9.8c0.4-0.7,0.4-1.6,0-2.2 l-5.6-9.8C20.7,2.4,19.9,2,19.1,2L19.1,2z"/><path fill="white" d="M21.1,24.9c-0.4,0.7-1.1,1.1-1.9,1.1H7.9c-0.8,0-1.5-0.4-1.9-1.1l-5.6-9.8C0.1,14.8,0,14.4,0,14v13h27V14 c0,0.4-0.1,0.8-0.3,1.1L21.1,24.9z"/><path fill="white" d="M0,0v14c0-0.4,0.1-0.8,0.3-1.1l5.6-9.8C6.3,2.4,7.1,2,7.9,2h11.3c0.8,0,1.5,0.4,1.9,1.1l5.6,9.8 c0.2,0.3,0.3,0.7,0.3,1.1V0H0z"/></svg>');
-    }
-
-    .origin {
-        margin-top: -0.25rem;
+    .account >>> .label {
+        padding-left: 0;
         transition: opacity .3s ease;
+        font-weight: unset;
+        opacity: 1;
     }
 
     .info-circle {
@@ -162,8 +139,8 @@ export default class PaymentInfoLine extends Vue {
         transition: opacity .3s ease;
     }
 
-    .description:hover .origin,
-    .description:focus .origin {
+    .description:hover .account >>> .label,
+    .description:focus .account >>> .label {
         opacity: .7;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 // Components
 export { default as Account } from './components/Account.vue';
-export { default as AccountInfo } from './components/AccountInfo.vue';
+export { default as AccountDetails } from './components/AccountDetails.vue';
 export { default as AccountList } from './components/AccountList.vue';
 export { default as AccountSelector } from './components/AccountSelector.vue';
 export { default as Address } from './components/Address.vue';

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -1,6 +1,6 @@
 import {storiesOf} from '@storybook/vue';
 import {action} from '@storybook/addon-actions';
-import {boolean, number, text, object, withKnobs} from '@storybook/addon-knobs';
+import {boolean, number, text, object, select, withKnobs} from '@storybook/addon-knobs';
 
 import Account from '../components/Account.vue';
 import AccountInfo from '../components/AccountInfo.vue';
@@ -619,50 +619,46 @@ storiesOf('Components', module)
 storiesOf('Pages', module)
     .addDecorator(withKnobs)
     .add('AccountInfo', () => {
+        const demoType = select('Demo Type', {
+            'Normal Account': 'normal',
+            'Merchant': 'merchant',
+        }, 'normal');
+
+        const demoData = {
+            normal: {
+                walletLabel: 'Keyguard Wallet',
+                account: {
+                    userFriendlyAddress: 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1',
+                    label: 'Savings',
+                    balance: 2712415141213,
+                },
+                origin: null,
+                shopLogoUrl: null,
+            },
+            merchant: {
+                walletLabel: null,
+                account: {
+                    userFriendlyAddress: 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1',
+                },
+                origin: 'https://shop.nimiq.com',
+                // shopLogoUrl: 'https://shop.nimiq.com/wp-content/uploads/2018/10/nimiq_signet_rgb_base_size.576px.png',
+                shopLogoUrl: 'https://www.decsa.com/wp-content/uploads/2016/10/mcds.png',
+            },
+        }[demoType];
+
         return {
             components: {AccountInfo, SmallPage},
             methods: {
                 close: action('close'),
             },
-            data() {
-                return {
-                    walletLabel: 'Keyguard Wallet',
-                    account: {
-                        userFriendlyAddress: 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1',
-                        label: 'Savings',
-                        balance: 2712415141213,
-                    },
-                };
-            },
-            template: windowTemplate(`<small-page style="height: 560px;">
-    <AccountInfo :address="account.userFriendlyAddress" :label="account.label" :balance="account.balance" :walletLabel="walletLabel" @close="close"/>
-</small-page>
-`),
-        };
-    })
-    .add('AccountInfo (merchant)', () => {
-        return {
-            components: {AccountInfo, SmallPage},
-            methods: {
-                close: action('close'),
-            },
-            data() {
-                return {
-                    walletLabel: 'Keyguard Wallet',
-                    account: {
-                        userFriendlyAddress: 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1',
-                        label: 'Savings',
-                        balance: 2712415141213,
-                    },
-                    origin: 'https://shop.nimiq.com',
-                    // shopLogoUrl: 'https://shop.nimiq.com/wp-content/uploads/2018/10/nimiq_signet_rgb_base_size.576px.png',
-                    shopLogoUrl: 'https://www.decsa.com/wp-content/uploads/2016/10/mcds.png',
-                };
-            },
-            template: windowTemplate(`<small-page style="height: 560px;">
-    <AccountInfo :address="account.userFriendlyAddress" :shopLogoUrl="shopLogoUrl" :origin="origin" @close="close"/>
-</small-page>
-`),
+            data: () => demoData,
+            template: windowTemplate(`
+                <small-page style="height: 560px;">
+                    <AccountInfo :address="account.userFriendlyAddress" :label="account.label"
+                    :balance="account.balance" :walletLabel="walletLabel"
+                    :shopLogoUrl="shopLogoUrl" :origin="origin" @close="close"/>
+                </small-page>
+            `),
         };
     });
 

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -104,32 +104,21 @@ storiesOf('Components', module)
         const label = text('label', 'My account');
         const address = text('address', 'NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM');
         const balance = number('balance', 12023110);
-
-        return {
-            components: {Account},
-            data() {
-                return { address };
-            },
-            template: `<Account :address="address" label="${label}" :balance="${balance}"></Account>`,
-        };
-    })
-    .add('Account (editable)', () => {
-        const label = text('label', 'My account');
-        const address = text('address', 'NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM');
-        const balance = number('balance', 12023110);
+        const editable = boolean('editable', false);
 
         return {
             components: {Account},
             methods: {
                 changed: action('changed'),
             },
-            data() {
-                return { address };
-            },
-            template: `<Account :address="address" label="${label}" :balance="${balance}" :editable="true" @changed="changed"></Account>`,
+            data: () => ({ address, label, balance, editable }),
+            template: `<Account :address="address" :label="label" :balance="balance"
+                :editable="editable" @changed="changed"></Account>`,
         };
     })
     .add('AccountList', () => {
+        const minBalance = number('minBalance', 1000) * 1e5;
+        const editable = boolean('editable', false);
         return {
             components: {AccountList},
             methods: {
@@ -154,10 +143,12 @@ storiesOf('Components', module)
                             balance: 12023110,
                         }
                     ],
-                    minBalance: 1000e5,
+                    minBalance,
+                    editable,
                 };
             },
-            template: `<AccountList @account-selected="accountSelected" :accounts="accounts" walletId="helloworld1" :minBalance="minBalance"/>`
+            template: `<AccountList @account-selected="accountSelected" :accounts="accounts" walletId="helloworld1"
+                :minBalance="minBalance" :editable="editable" />`
         };
     })
     .add('AccountSelector', () => {

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -3,7 +3,7 @@ import {action} from '@storybook/addon-actions';
 import {boolean, number, text, object, select, withKnobs} from '@storybook/addon-knobs';
 
 import Account from '../components/Account.vue';
-import AccountInfo from '../components/AccountInfo.vue';
+import AccountDetails from '../components/AccountDetails.vue';
 import AccountList from '../components/AccountList.vue';
 import AccountSelector from '../components/AccountSelector.vue';
 import Address from '../components/Address.vue';
@@ -619,7 +619,7 @@ storiesOf('Components', module)
 
 storiesOf('Pages', module)
     .addDecorator(withKnobs)
-    .add('AccountInfo', () => {
+    .add('AccountDetails', () => {
         const demoType = select('Demo Type', {
             'Normal Account': 'normal',
             'Merchant': 'merchant',
@@ -648,7 +648,7 @@ storiesOf('Pages', module)
         }[demoType];
 
         return {
-            components: {AccountInfo, SmallPage},
+            components: {AccountDetails, SmallPage},
             methods: {
                 close: action('close'),
             },
@@ -660,7 +660,7 @@ storiesOf('Pages', module)
             },
             template: windowTemplate(`
                 <small-page style="height: 560px;">
-                    <AccountInfo :address="account.userFriendlyAddress" :label="label"
+                    <AccountDetails :address="account.userFriendlyAddress" :label="label"
                     :balance="account.balance" :walletLabel="walletLabel"
                     :image="shopLogoUrl" @close="close"/>
                 </small-page>
@@ -672,7 +672,7 @@ storiesOf('Pages/Checkout', module)
     .addDecorator(withKnobs)
     .add('AccountSelector (one wallet)', () => {
         return {
-            components: {AccountSelector, PaymentInfoLine, AccountInfo, SmallPage},
+            components: {AccountSelector, PaymentInfoLine, AccountDetails, SmallPage},
             methods: {
                 accountSelected: action('account-selected'),
                 login: action('login'),
@@ -725,14 +725,14 @@ storiesOf('Pages/Checkout', module)
     <PaymentInfoLine :amount="amount" :fee="fee" :address="shopAddress" :origin="origin" :shopLogoUrl="shopLogoUrl" @merchant-info-clicked="openMerchantInfo"/>
     <h1 style="font-size: 3rem; text-align: center; margin: 3rem 0 1rem; line-height: 1;">Choose an account to pay</h1>
     <AccountSelector @account-selected="accountSelected" @login="login" :wallets="wallets" :minBalance="amount + fee"/>
-    <AccountInfo v-if="showMerchantInfo" :address="shopAddress" :label="originDomain" :image="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
+    <AccountDetails v-if="showMerchantInfo" :address="shopAddress" :label="originDomain" :image="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
 </small-page>
 `),
         };
     })
     .add('AccountSelector (two wallets)', () => {
         return {
-            components: {AccountSelector, PaymentInfoLine, AccountInfo, SmallPage},
+            components: {AccountSelector, PaymentInfoLine, AccountDetails, SmallPage},
             methods: {
                 accountSelected: action('account-selected'),
                 login: action('login'),
@@ -808,7 +808,7 @@ storiesOf('Pages/Checkout', module)
     <PaymentInfoLine :amount="amount" :fee="fee" :address="shopAddress" :origin="origin" :shopLogoUrl="shopLogoUrl" @merchant-info-clicked="openMerchantInfo"/>
     <h1 style="font-size: 3rem; text-align: center; margin: 3rem 0 1rem; line-height: 1;">Choose an account to pay</h1>
     <AccountSelector @account-selected="accountSelected" @login="login" :wallets="wallets" :minBalance="amount + fee"/>
-    <AccountInfo v-if="showMerchantInfo" :address="shopAddress" :label="originDomain" :image="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
+    <AccountDetails v-if="showMerchantInfo" :address="shopAddress" :label="originDomain" :image="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
 </small-page>
 `),
         };

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -101,19 +101,26 @@ storiesOf('Basic', module)
 storiesOf('Components', module)
     .addDecorator(withKnobs)
     .add('Account', () => {
-        const label = text('label', 'My account');
-        const address = text('address', 'NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM');
-        const balance = number('balance', 12023110);
-        const editable = boolean('editable', false);
+        const layout = select('Layout', ['row', 'column'], 'row');
+        const address = text('Address', 'NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM');
+        const label = text('Label', 'My account');
+        const walletLabel = text('Wallet Label', '');
+        const image = select('Image Url', {
+            'None': '',
+            'Restaurant Golden Swallow': 'https://www.decsa.com/wp-content/uploads/2016/10/mcds.png',
+            'Invalid Image': 'javascript:alert(1)',
+        }, '');
+        const balance = number('Balance (can be empty)', 12023110);
+        const editable = boolean('Editable', false);
 
         return {
             components: {Account},
             methods: {
                 changed: action('changed'),
             },
-            data: () => ({ address, label, balance, editable }),
-            template: `<Account :address="address" :label="label" :balance="balance"
-                :editable="editable" @changed="changed"></Account>`,
+            data: () => ({ layout, address, label, walletLabel, image, balance, editable }),
+            template: `<Account :layout="layout" :address="address" :label="label" :walletLabel="walletLabel"
+                :image="image" :balance="balance" :editable="editable" @changed="changed"></Account>`,
         };
     })
     .add('AccountList', () => {

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -630,7 +630,7 @@ storiesOf('Pages', module)
                 walletLabel: 'Keyguard Wallet',
                 account: {
                     userFriendlyAddress: 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1',
-                    label: 'Savings',
+                    label: 'Savings Account',
                     balance: 2712415141213,
                 },
                 origin: null,
@@ -641,7 +641,7 @@ storiesOf('Pages', module)
                 account: {
                     userFriendlyAddress: 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1',
                 },
-                origin: 'https://shop.nimiq.com',
+                origin: 'https://macces.com',
                 // shopLogoUrl: 'https://shop.nimiq.com/wp-content/uploads/2018/10/nimiq_signet_rgb_base_size.576px.png',
                 shopLogoUrl: 'https://www.decsa.com/wp-content/uploads/2016/10/mcds.png',
             },
@@ -653,11 +653,16 @@ storiesOf('Pages', module)
                 close: action('close'),
             },
             data: () => demoData,
+            computed: {
+                label() {
+                    return this.account.label || this.origin.split('://')[1];
+                }
+            },
             template: windowTemplate(`
                 <small-page style="height: 560px;">
-                    <AccountInfo :address="account.userFriendlyAddress" :label="account.label"
+                    <AccountInfo :address="account.userFriendlyAddress" :label="label"
                     :balance="account.balance" :walletLabel="walletLabel"
-                    :shopLogoUrl="shopLogoUrl" :origin="origin" @close="close"/>
+                    :image="shopLogoUrl" @close="close"/>
                 </small-page>
             `),
         };
@@ -711,6 +716,7 @@ storiesOf('Pages/Checkout', module)
                     fee: 138,
                     shopAddress: 'NQ21 YPRN 1KVN BQP5 A17U YGD3 HH96 6TKA 6BL4',
                     origin: 'https://mcdonalds.com',
+                    originDomain: 'mcdonalds.com',
                     shopLogoUrl: 'https://brandmark.io/logo-rank/random/mcdonalds.png',
                     showMerchantInfo: false,
                 };
@@ -719,7 +725,7 @@ storiesOf('Pages/Checkout', module)
     <PaymentInfoLine :amount="amount" :fee="fee" :address="shopAddress" :origin="origin" :shopLogoUrl="shopLogoUrl" @merchant-info-clicked="openMerchantInfo"/>
     <h1 style="font-size: 3rem; text-align: center; margin: 3rem 0 1rem; line-height: 1;">Choose an account to pay</h1>
     <AccountSelector @account-selected="accountSelected" @login="login" :wallets="wallets" :minBalance="amount + fee"/>
-    <AccountInfo v-if="showMerchantInfo" :address="shopAddress" :origin="origin" :shopLogoUrl="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
+    <AccountInfo v-if="showMerchantInfo" :address="shopAddress" :label="originDomain" :image="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
 </small-page>
 `),
         };
@@ -793,6 +799,7 @@ storiesOf('Pages/Checkout', module)
                     fee: 138,
                     shopAddress: 'NQ21 YPRN 1KVN BQP5 A17U YGD3 HH96 6TKA 6BL4',
                     origin: 'https://shop.nimiq.com',
+                    originDomain: 'shop.nimiq.com',
                     shopLogoUrl: 'https://shop.nimiq.com/wp-content/uploads/2018/10/nimiq_signet_rgb_base_size.576px.png',
                     showMerchantInfo: false,
                 };
@@ -801,7 +808,7 @@ storiesOf('Pages/Checkout', module)
     <PaymentInfoLine :amount="amount" :fee="fee" :address="shopAddress" :origin="origin" :shopLogoUrl="shopLogoUrl" @merchant-info-clicked="openMerchantInfo"/>
     <h1 style="font-size: 3rem; text-align: center; margin: 3rem 0 1rem; line-height: 1;">Choose an account to pay</h1>
     <AccountSelector @account-selected="accountSelected" @login="login" :wallets="wallets" :minBalance="amount + fee"/>
-    <AccountInfo v-if="showMerchantInfo" :address="shopAddress" :origin="origin" :shopLogoUrl="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
+    <AccountInfo v-if="showMerchantInfo" :address="shopAddress" :label="originDomain" :image="shopLogoUrl" @close="closeMerchantInfo" style="position: absolute; left: 0; top: 0;"/>
 </small-page>
 `),
         };

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -514,7 +514,9 @@ storiesOf('Components', module)
         };
     })
     .add('PaymentInfoLine', () => {
+        const address = text('address', 'NQ07 0000 00000000 0000 0000 0000 0000 0000');
         const origin = text('origin', 'https://shop.nimiq.com');
+        const shopLogo = text('shopLogo', 'https://www.decsa.com/wp-content/uploads/2016/10/mcds.png');
         const amount = number('amount', 199862);
         const fee = number('fee', 138);
         return {
@@ -522,7 +524,8 @@ storiesOf('Components', module)
             methods: {
                 merchantInfoClicked: action('merchant-info-clicked'),
             },
-            template: `<div style="width: 400px"><PaymentInfoLine :amount="${amount}" :fee="${fee}" origin="${origin}" @merchant-info-clicked="merchantInfoClicked"/></div>`,
+            template: `<div style="width: 400px"><PaymentInfoLine address="${address}" :amount="${amount}" :fee="${fee}"
+                origin="${origin}" shopLogoUrl="${shopLogo}" @merchant-info-clicked="merchantInfoClicked"/></div>`,
         };
     })
     .add('QrCode', () => {


### PR DESCRIPTION
I needed a component that displays an identicon or shop Logo together with a label in a column layout.
Two options would have been to create a new component for that or to add a `compact` flag or something like that to the `AccountInfo` component which is closest implementation wise.
The second approach is the one used in the keyguard (where the more compact `AddressInfo` version can be expanded with more details via a `isDetailedView` flag).

However, as in vue-components there are already quite some `Account*`, `Address*`, `Wallet*`, `Contact*` components, I didn't want to further add to that confusion. Therefore I didn't want to add a new component. Also, I thought the missing separation of concerns between an inline component and a full page component that sort of arbitrarily changes its semantics by setting a flag (becoming a full screen view with added details and a close button) would not help to reduce the clutter.

Instead, I decided to consolidate functionality in the basic `Account` component which was then also used in `AccountInfo` and `PaymentInfoLine` to remove some code duplication.
Additionally, the account renaming screen in the new designs will be straight forward to implement with the already existing label editing functionality in the `Account` component.

Also some demos have been refactored / consolidated / made more interactive by adding knobs.

Lastly, the `AccountInfo` component was renamed to `AccountDetails` to avoid confusion with the `AccountInfo` interface we have in the account manager.