### PR TITLE
Add Icon component

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,16 +1,33 @@
+const path = require('path');
+
 module.exports = (storybookBaseConfig, env, config) => {
     return {
         ...config,
         plugins: [...config.plugins, new (require('vue-loader/lib/plugin'))()],
         module: {
             ...config.module,
-            rules: [...config.module.rules, {
+                                           // Remove default SVG rule to add a custom one below
+            rules: [...config.module.rules.filter(rule => !rule.test.toString().includes('svg')), {
                 test: /\.tsx?$/,
                 loader: require.resolve('ts-loader'),
                 options: {
                     appendTsSuffixTo: [/\.vue$/],
                     transpileOnly: true
                 }
+            }, {
+                test: /\.(svg)(\?.*)?$/,
+                oneOf: [{
+                    test: /icons/,
+                    loader: 'svg-sprite-loader',
+                    options: {
+                        symbolId: filePath => `nq-${path.basename(filePath, '.svg')}`
+                    }
+                }, {
+                    loader: 'file-loader',
+                    options: {
+                        name: 'img/[name].[hash:8].[ext]'
+                    }
+                }],
             }]
         },
         resolve: {

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,13 +1,16 @@
 const path = require('path');
 
 module.exports = (storybookBaseConfig, env, config) => {
+    // Save and remove default SVG rule to add a custom one below
+    const svgRule = config.module.rules.find(rule => rule.test.toString().includes('svg'));
+    config.module.rules = config.module.rules.filter(rule => !rule.test.toString().includes('svg'));
+
     return {
         ...config,
         plugins: [...config.plugins, new (require('vue-loader/lib/plugin'))()],
         module: {
             ...config.module,
-                                           // Remove default SVG rule to add a custom one below
-            rules: [...config.module.rules.filter(rule => !rule.test.toString().includes('svg')), {
+            rules: [...config.module.rules, {
                 test: /\.tsx?$/,
                 loader: require.resolve('ts-loader'),
                 options: {
@@ -15,18 +18,18 @@ module.exports = (storybookBaseConfig, env, config) => {
                     transpileOnly: true
                 }
             }, {
-                test: /\.(svg)(\?.*)?$/,
+                test: svgRule.test,
                 oneOf: [{
+                    // Add new icon SVG rule
                     test: /icons/,
                     loader: 'svg-sprite-loader',
                     options: {
                         symbolId: filePath => `nq-${path.basename(filePath, '.svg')}`
                     }
                 }, {
-                    loader: 'file-loader',
-                    options: {
-                        name: 'img/[name].[hash:8].[ext]'
-                    }
+                    // Re-add default SVG rule
+                    loader: svgRule.loader,
+                    options: svgRule.options
                 }],
             }]
         },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "storybook": "start-storybook -p 6006 -c .storybook -s ."
   },
   "dependencies": {
-    "@nimiq/style": "^0.6.0",
+    "@nimiq/style": "^0.6.4",
     "vue": "^2.5.17",
     "vue-property-decorator": "^7.0.0"
   },
@@ -35,6 +35,7 @@
     "moment": "^2.22.2",
     "qr-code": "github:nimiq/qr-encoder",
     "qr-scanner": "^1.1.1",
+    "svg-sprite-loader": "^4.1.6",
     "ts-loader": "^4.4.2",
     "typescript": "^3.0.1",
     "vue-cli-plugin-ts-bundler": "^0.0.3",

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -9,47 +9,42 @@ import {Component, Prop, Vue} from 'vue-property-decorator';
  * # Icons
  *
  * Comment out the ones not used for the build target.
- *
- * The call to each imported icon at the end of each line is because the imported
- * variable has to be used to be processed by webpack. The assignment to _ is to
- * avoid unused-expression warnings by tslint for this file.
  */
-let _;
-import AlertTriangle from '@nimiq/style/src/icons/alert-triangle.svg'; _ = AlertTriangle;
-import ArrowLeftSmall from '@nimiq/style/src/icons/arrow-left-small.svg'; _ = ArrowLeftSmall;
-import ArrowLeft from '@nimiq/style/src/icons/arrow-left.svg'; _ = ArrowLeft;
-import ArrowRightSmall from '@nimiq/style/src/icons/arrow-right-small.svg'; _ = ArrowRightSmall;
-import ArrowRight from '@nimiq/style/src/icons/arrow-right.svg'; _ = ArrowRight;
-import BrowserLogin from '@nimiq/style/src/icons/browser-login.svg'; _ = BrowserLogin;
-import CaretRightSmall from '@nimiq/style/src/icons/caret-right-small.svg'; _ = CaretRightSmall;
-import Checkmark from '@nimiq/style/src/icons/checkmark.svg'; _ = Checkmark;
-import Close from '@nimiq/style/src/icons/close.svg'; _ = Close;
-import Contacts from '@nimiq/style/src/icons/contacts.svg'; _ = Contacts;
-import Copy from '@nimiq/style/src/icons/copy.svg'; _ = Copy;
-import Download from '@nimiq/style/src/icons/download.svg'; _ = Download;
-import FaceNeutral from '@nimiq/style/src/icons/face-neutral.svg'; _ = FaceNeutral;
-import FaceSad from '@nimiq/style/src/icons/face-sad.svg'; _ = FaceSad;
-import Fire from '@nimiq/style/src/icons/fire.svg'; _ = Fire;
-import Gear from '@nimiq/style/src/icons/gear.svg'; _ = Gear;
-import Hexagon from '@nimiq/style/src/icons/hexagon.svg'; _ = Hexagon;
-import InfoCircle from '@nimiq/style/src/icons/info-circle.svg'; _ = InfoCircle;
-import Keys from '@nimiq/style/src/icons/keys.svg'; _ = Keys;
-import Ledger from '@nimiq/style/src/icons/ledger.svg'; _ = Ledger;
-import LockLocked from '@nimiq/style/src/icons/lock-locked.svg'; _ = LockLocked;
-import LockUnlocked from '@nimiq/style/src/icons/lock-unlocked.svg'; _ = LockUnlocked;
-import Login from '@nimiq/style/src/icons/login.svg'; _ = Login;
-import MenuDots from '@nimiq/style/src/icons/menu-dots.svg'; _ = MenuDots;
-import PaperEdit from '@nimiq/style/src/icons/paper-edit.svg'; _ = PaperEdit;
-import PlusCircle from '@nimiq/style/src/icons/plus-circle.svg'; _ = PlusCircle;
-import QrCode from '@nimiq/style/src/icons/qr-code.svg'; _ = QrCode;
-import Questionmark from '@nimiq/style/src/icons/questionmark.svg'; _ = Questionmark;
-import ScanQrCode from '@nimiq/style/src/icons/scan-qr-code.svg'; _ = ScanQrCode;
-import Settings from '@nimiq/style/src/icons/settings.svg'; _ = Settings;
-import Shredder from '@nimiq/style/src/icons/shredder.svg'; _ = Shredder;
-import Skull from '@nimiq/style/src/icons/skull.svg'; _ = Skull;
-import Transfer from '@nimiq/style/src/icons/transfer.svg'; _ = Transfer;
-import ViewOff from '@nimiq/style/src/icons/view-off.svg'; _ = ViewOff;
-import View from '@nimiq/style/src/icons/view.svg'; _ = View;
+import '@nimiq/style/src/icons/alert-triangle.svg';
+import '@nimiq/style/src/icons/arrow-left-small.svg';
+import '@nimiq/style/src/icons/arrow-left.svg';
+import '@nimiq/style/src/icons/arrow-right-small.svg';
+import '@nimiq/style/src/icons/arrow-right.svg';
+import '@nimiq/style/src/icons/browser-login.svg';
+import '@nimiq/style/src/icons/caret-right-small.svg';
+import '@nimiq/style/src/icons/checkmark.svg';
+import '@nimiq/style/src/icons/close.svg';
+import '@nimiq/style/src/icons/contacts.svg';
+import '@nimiq/style/src/icons/copy.svg';
+import '@nimiq/style/src/icons/download.svg';
+import '@nimiq/style/src/icons/face-neutral.svg';
+import '@nimiq/style/src/icons/face-sad.svg';
+import '@nimiq/style/src/icons/fire.svg';
+import '@nimiq/style/src/icons/gear.svg';
+import '@nimiq/style/src/icons/hexagon.svg';
+import '@nimiq/style/src/icons/info-circle.svg';
+import '@nimiq/style/src/icons/keys.svg';
+import '@nimiq/style/src/icons/ledger.svg';
+import '@nimiq/style/src/icons/lock-locked.svg';
+import '@nimiq/style/src/icons/lock-unlocked.svg';
+import '@nimiq/style/src/icons/login.svg';
+import '@nimiq/style/src/icons/menu-dots.svg';
+import '@nimiq/style/src/icons/paper-edit.svg';
+import '@nimiq/style/src/icons/plus-circle.svg';
+import '@nimiq/style/src/icons/qr-code.svg';
+import '@nimiq/style/src/icons/questionmark.svg';
+import '@nimiq/style/src/icons/scan-qr-code.svg';
+import '@nimiq/style/src/icons/settings.svg';
+import '@nimiq/style/src/icons/shredder.svg';
+import '@nimiq/style/src/icons/skull.svg';
+import '@nimiq/style/src/icons/transfer.svg';
+import '@nimiq/style/src/icons/view-off.svg';
+import '@nimiq/style/src/icons/view.svg';
 
 @Component
 export default class Icon extends Vue {

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -1,0 +1,62 @@
+<template>
+    <svg class="nq-icon" v-html="useTag"></svg>
+</template>
+
+<script lang="ts">
+import {Component, Prop, Vue} from 'vue-property-decorator';
+
+/**
+ * # Icons
+ *
+ * Comment out the ones not used for the build target.
+ *
+ * The call to each imported icon at the end of each line is because the imported
+ * variable has to be used to be processed by webpack. The assignment to _ is to
+ * avoid unused-expression warnings by tslint for this file.
+ */
+let _;
+import AlertTriangle from '@nimiq/style/src/icons/alert-triangle.svg'; _ = AlertTriangle;
+import ArrowLeftSmall from '@nimiq/style/src/icons/arrow-left-small.svg'; _ = ArrowLeftSmall;
+import ArrowLeft from '@nimiq/style/src/icons/arrow-left.svg'; _ = ArrowLeft;
+import ArrowRightSmall from '@nimiq/style/src/icons/arrow-right-small.svg'; _ = ArrowRightSmall;
+import ArrowRight from '@nimiq/style/src/icons/arrow-right.svg'; _ = ArrowRight;
+import BrowserLogin from '@nimiq/style/src/icons/browser-login.svg'; _ = BrowserLogin;
+import CaretRightSmall from '@nimiq/style/src/icons/caret-right-small.svg'; _ = CaretRightSmall;
+import Checkmark from '@nimiq/style/src/icons/checkmark.svg'; _ = Checkmark;
+import Close from '@nimiq/style/src/icons/close.svg'; _ = Close;
+import Contacts from '@nimiq/style/src/icons/contacts.svg'; _ = Contacts;
+import Copy from '@nimiq/style/src/icons/copy.svg'; _ = Copy;
+import Download from '@nimiq/style/src/icons/download.svg'; _ = Download;
+import FaceNeutral from '@nimiq/style/src/icons/face-neutral.svg'; _ = FaceNeutral;
+import FaceSad from '@nimiq/style/src/icons/face-sad.svg'; _ = FaceSad;
+import Fire from '@nimiq/style/src/icons/fire.svg'; _ = Fire;
+import Gear from '@nimiq/style/src/icons/gear.svg'; _ = Gear;
+import Hexagon from '@nimiq/style/src/icons/hexagon.svg'; _ = Hexagon;
+import InfoCircle from '@nimiq/style/src/icons/info-circle.svg'; _ = InfoCircle;
+import Keys from '@nimiq/style/src/icons/keys.svg'; _ = Keys;
+import Ledger from '@nimiq/style/src/icons/ledger.svg'; _ = Ledger;
+import LockLocked from '@nimiq/style/src/icons/lock-locked.svg'; _ = LockLocked;
+import LockUnlocked from '@nimiq/style/src/icons/lock-unlocked.svg'; _ = LockUnlocked;
+import Login from '@nimiq/style/src/icons/login.svg'; _ = Login;
+import MenuDots from '@nimiq/style/src/icons/menu-dots.svg'; _ = MenuDots;
+import PaperEdit from '@nimiq/style/src/icons/paper-edit.svg'; _ = PaperEdit;
+import PlusCircle from '@nimiq/style/src/icons/plus-circle.svg'; _ = PlusCircle;
+import QrCode from '@nimiq/style/src/icons/qr-code.svg'; _ = QrCode;
+import Questionmark from '@nimiq/style/src/icons/questionmark.svg'; _ = Questionmark;
+import ScanQrCode from '@nimiq/style/src/icons/scan-qr-code.svg'; _ = ScanQrCode;
+import Settings from '@nimiq/style/src/icons/settings.svg'; _ = Settings;
+import Shredder from '@nimiq/style/src/icons/shredder.svg'; _ = Shredder;
+import Skull from '@nimiq/style/src/icons/skull.svg'; _ = Skull;
+import Transfer from '@nimiq/style/src/icons/transfer.svg'; _ = Transfer;
+import ViewOff from '@nimiq/style/src/icons/view-off.svg'; _ = ViewOff;
+import View from '@nimiq/style/src/icons/view.svg'; _ = View;
+
+@Component
+export default class Icon extends Vue {
+    @Prop(String) private name!: string;
+
+    private get useTag() {
+        return `<use xlink:href="#nq-${this.name}"/>`;
+    }
+}
+</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ export { default as Amount } from './components/Amount.vue';
 export { default as AmountWithDetails } from './components/AmountWithDetails.vue';
 export { default as Contact } from './components/Contact.vue';
 export { default as ContactList } from './components/ContactList.vue';
+export { default as Icon } from './components/Icon.vue';
 export { default as Identicon } from './components/Identicon.vue';
 export { default as LabelInput } from './components/LabelInput.vue';
 export { default as LoadingSpinner } from './components/LoadingSpinner.vue';

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -13,6 +13,7 @@ import Amount from '../components/Amount.vue';
 import AmountWithDetails from '../components/AmountWithDetails.vue';
 import Contact from '../components/Contact.vue';
 import ContactList from '../components/ContactList.vue';
+import Icon from '../components/Icon.vue';
 import Identicon from '../components/Identicon.vue';
 import LabelInput from '../components/LabelInput.vue';
 import Wallet from '../components/Wallet.vue';
@@ -52,6 +53,49 @@ storiesOf('Basic', module)
             components: {Amount},
             style: `td { text-align: right }`,
             template
+        };
+    })
+    .add('Icon', () => {
+        return {
+            components: {Icon},
+            template: `
+                <div style="font-size: 40px; color: var(--nimiq-blue); padding: 16px;">
+                    <Icon name="alert-triangle"/>
+                    <Icon name="arrow-left-small"/>
+                    <Icon name="arrow-left"/>
+                    <Icon name="arrow-right-small"/>
+                    <Icon name="arrow-right"/>
+                    <Icon name="browser-login"/>
+                    <Icon name="caret-right-small"/>
+                    <Icon name="checkmark"/>
+                    <Icon name="close"/>
+                    <Icon name="contacts"/>
+                    <Icon name="copy"/>
+                    <Icon name="download"/>
+                    <Icon name="face-neutral"/>
+                    <Icon name="face-sad"/>
+                    <Icon name="fire"/>
+                    <Icon name="gear"/>
+                    <Icon name="hexagon"/>
+                    <Icon name="info-circle"/>
+                    <Icon name="keys"/>
+                    <Icon name="ledger"/>
+                    <Icon name="lock-locked"/>
+                    <Icon name="lock-unlocked"/>
+                    <Icon name="login"/>
+                    <Icon name="menu-dots"/>
+                    <Icon name="paper-edit"/>
+                    <Icon name="plus-circle"/>
+                    <Icon name="qr-code"/>
+                    <Icon name="questionmark"/>
+                    <Icon name="scan-qr-code"/>
+                    <Icon name="settings"/>
+                    <Icon name="shredder"/>
+                    <Icon name="skull"/>
+                    <Icon name="transfer"/>
+                    <Icon name="view-off"/>
+                    <Icon name="view"/>
+                </div>`,
         };
     })
     .add('Identicon', () => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path');
+const path = require('path');
 
 const configureWebpack = {
   resolve: {
@@ -22,4 +22,32 @@ if (process.argv.includes('build')) {
   };
 }
 
-module.exports = { configureWebpack };
+const chainWebpack = config => {
+  // Delete default SVG rule to replace it
+  config.module.rules.delete('svg');
+
+  config.module
+    .rule('svg')
+      .test(/\.(svg)(\?.*)?$/)
+        // Add new icon SVG rule
+        .oneOf('icons')
+          .test(/icons/)
+          .use('svg-sprite-loader')
+            .loader('svg-sprite-loader')
+            .options({
+              symbolId: filePath => `nq-${path.basename(filePath, '.svg')}`
+            })
+            .end()
+          .end()
+        // Re-add default svg rule
+        .oneOf('normal')
+          .use('file-loader')
+            .loader('file-loader')
+            .options({
+              name: 'img/[name].[hash:8].[ext]'
+            })
+            .end()
+          .end()
+}
+
+module.exports = { configureWebpack, chainWebpack };

--- a/vue.config.js
+++ b/vue.config.js
@@ -23,31 +23,29 @@ if (process.argv.includes('build')) {
 }
 
 const chainWebpack = config => {
-  // Delete default SVG rule to replace it
-  config.module.rules.delete('svg');
+  const svgRule = config.module.rule('svg');
+  const svgDefaultHandler = svgRule.uses.values()[0];
+  svgRule.uses.clear();
 
   config.module
     .rule('svg')
-      .test(/\.(svg)(\?.*)?$/)
-        // Add new icon SVG rule
-        .oneOf('icons')
-          .test(/icons/)
-          .use('svg-sprite-loader')
-            .loader('svg-sprite-loader')
-            .options({
-              symbolId: filePath => `nq-${path.basename(filePath, '.svg')}`
-            })
-            .end()
+      // Add new icon SVG rule
+      .oneOf('icons')
+        .test(/icons/)
+        .use('svg-sprite-loader')
+          .loader('svg-sprite-loader')
+          .options({
+            symbolId: filePath => `nq-${path.basename(filePath, '.svg')}`
+          })
           .end()
-        // Re-add default svg rule
-        .oneOf('normal')
-          .use('file-loader')
-            .loader('file-loader')
-            .options({
-              name: 'img/[name].[hash:8].[ext]'
-            })
-            .end()
+        .end()
+      // Re-add default SVG rule
+      .oneOf('default')
+        .use()
+          .loader(svgDefaultHandler.get('loader'))
+          .options(svgDefaultHandler.get('options'))
           .end()
+        .end()
 }
 
 module.exports = { configureWebpack, chainWebpack };

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,10 +756,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.1.1.tgz#9ec533ce285e334f58ee857557b47605c2863305"
   integrity sha512-Z7/i/s6C1X1u4iBGBRkdas0jP9gTgHCUB1DH2NAvzXscGgbmrxU7RE8dABLxlNYwQVXEZKcKyPUz5FQTGNDKvg==
 
-"@nimiq/style@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.6.0.tgz#27600b7cd11f1fc0ec7f8a17b64aa9fb15fb20ce"
-  integrity sha512-Vv7Ut5rLVF06Nl4C679TX7uY2TrUdg3LScgFq7S0oqyokvj/O8n2jG294AMvRVdDuaLBRaoFSB+YSnABeWdYVQ==
+"@nimiq/style@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.6.4.tgz#467dc71e41978ef2316b80e8e5c6a973589c2432"
+  integrity sha512-A/OQC92IvunKGs3OlMxILznrjYE0E4Z0IjAFEVzQxmA0aCL7dXfVY0Qi2lCM7quFz8bt7CX1H+oPBPapvqMnhw==
 
 "@nimiq/utils@^0.2.0":
   version "0.2.0"
@@ -3033,6 +3033,11 @@ bluebird@^3.1.1, bluebird@^3.5.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
+bluebird@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -3093,7 +3098,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.0, braces@^2.3.1:
+braces@^2.2.2, braces@^2.3.0, braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
@@ -3543,6 +3548,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 co@^4.6.0:
   version "4.6.0"
@@ -4374,6 +4384,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deepmerge@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.3.2.tgz#1663691629d4dbfe364fa12a2a4f0aa86aa3a050"
+  integrity sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=
+
 deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
@@ -4584,6 +4599,11 @@ domelementtype@1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
   integrity sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=
 
+domelementtype@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
@@ -4596,6 +4616,18 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
+domready@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/domready/-/domready-1.0.8.tgz#91f252e597b65af77e745ae24dd0185d5e26d58c"
+  integrity sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
@@ -4607,6 +4639,14 @@ domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
   integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -4770,6 +4810,11 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+entities@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@~1.1.1:
   version "1.1.1"
@@ -5082,7 +5127,7 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extglob@^2.0.4:
+extglob@^2.0.2, extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
   integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
@@ -5756,6 +5801,11 @@ he@1.1.x, he@^1.1.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
   integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
+he@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
@@ -5865,6 +5915,18 @@ html-webpack-plugin@^3.2.0:
     tapable "^1.0.0"
     toposort "^1.0.0"
     util.promisify "1.0.0"
+
+htmlparser2@^3.8.3:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
 
 htmlparser2@~3.3.0:
   version "3.3.0"
@@ -5989,6 +6051,11 @@ ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
+image-size@^0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+  integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
 immutable@^3.8.1:
   version "3.8.2"
@@ -6370,7 +6437,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -6475,7 +6542,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isobject@^2.0.0:
+isobject@^2.0.0, isobject@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
@@ -6673,7 +6740,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0:
+kind-of@^5.0.0, kind-of@^5.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
@@ -7020,6 +7087,13 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-options@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
+  integrity sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==
+  dependencies:
+    is-plain-obj "^1.1"
+
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -7036,6 +7110,25 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromatch@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.0.tgz#5102d4eaf20b6997d6008e3acfe1c44a3fa815e2"
+  integrity sha512-3StSelAE+hnRvMs8IdVW7Uhk8CVed5tp+kLLGlBP6WiRAXS21GPGu/Nat4WNPXj2Eoc24B02SaeoyozPMfj0/g==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.2.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    extglob "^2.0.2"
+    fragment-cache "^0.2.1"
+    kind-of "^5.0.2"
+    nanomatch "^1.2.1"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -7210,6 +7303,11 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mitt@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.2.tgz#380e61480d6a615b660f07abb60d51e0a4e4bed6"
+  integrity sha1-OA5hSA1qYVtmDwertg1R4KTkvtY=
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
@@ -7274,6 +7372,23 @@ nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
   integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
+
+nanomatch@^1.2.1:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -8649,6 +8764,13 @@ postcss-ordered-values@^4.1.1:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-prefix-selector@^1.6.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/postcss-prefix-selector/-/postcss-prefix-selector-1.7.1.tgz#c5f883e2366a823bd68bee847f87314d6b8ba3db"
+  integrity sha512-eNgr0xRk2IUPWpPkzfLL/Dlrewo4vd4vYpDj92/TEPNsLKTArAL/Y9VWFpJzrK8iPEpekPA06Ux97v8ByZ9QCQ==
+  dependencies:
+    postcss "^7.0.0"
+
 postcss-reduce-idents@^2.2.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz#c2c6d20cc958284f6abfbe63f7609bf409059ad3"
@@ -8816,7 +8938,7 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
-postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16:
+postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16, postcss@^5.2.17:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
@@ -8861,6 +8983,44 @@ postcss@^7.0.1, postcss@^7.0.5:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.5.0"
+
+posthtml-parser@^0.2.0, posthtml-parser@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.2.1.tgz#35d530de386740c2ba24ff2eb2faf39ccdf271dd"
+  integrity sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=
+  dependencies:
+    htmlparser2 "^3.8.3"
+    isobject "^2.1.0"
+
+posthtml-rename-id@^1.0:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/posthtml-rename-id/-/posthtml-rename-id-1.0.11.tgz#02281a1e4482aa3c8c30f798cf9a888e32d9275c"
+  integrity sha512-8doF8+w+WJT4AZuLVC0feA8Yy7g00IUmZw3YDKn8CKx0uC8FLbCH7JaGMbDOE1ArjyZsJMt1vmyP+IZ8SnNmXw==
+  dependencies:
+    escape-string-regexp "1.0.5"
+
+posthtml-render@^1.0.5, posthtml-render@^1.0.6:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.4.tgz#95dac09892f4f183fad5ac823f08f42c0256551e"
+  integrity sha512-jL6eFIzoN3xUEvbo33OAkSDE2VIKU4JQ1wENOows1DpfnrdapR/K3Q1/fB43Mq7wQlcSgRm23nFrvoioufM7eA==
+
+posthtml-svg-mode@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/posthtml-svg-mode/-/posthtml-svg-mode-1.0.3.tgz#abd554face81223cab0cb367e18e4efd2a4e74b0"
+  integrity sha512-hEqw9NHZ9YgJ2/0G7CECOeuLQKZi8HjWLkBaSVtOWjygQ9ZD8P7tqeowYs7WrFdKsWEKG7o+IlsPY8jrr0CJpQ==
+  dependencies:
+    merge-options "1.0.1"
+    posthtml "^0.9.2"
+    posthtml-parser "^0.2.1"
+    posthtml-render "^1.0.6"
+
+posthtml@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.9.2.tgz#f4c06db9f67b61fd17c4e256e7e3d9515bf726fd"
+  integrity sha1-9MBtufZ7Yf0XxOJW5+PZUVv3Jv0=
+  dependencies:
+    posthtml-parser "^0.2.0"
+    posthtml-render "^1.0.5"
 
 prepend-http@^1.0.0:
   version "1.0.4"
@@ -9032,7 +9192,7 @@ qs@^6.5.2, qs@~6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
@@ -9285,6 +9445,15 @@ readable-stream@1.0:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -10230,6 +10399,13 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -10316,6 +10492,49 @@ supports-color@^5.5.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+svg-baker-runtime@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/svg-baker-runtime/-/svg-baker-runtime-1.4.1.tgz#d3f77dffdf1f1a8b8f1e84ef67d2c1b53d60d770"
+  integrity sha512-4HLs8dU5kP4+zWix3MoZUge7kSVO6VCg14dLJWVIRWZx1vik21k/h5T620VXRoIyn0nw8g1R8Qk+VvW9BLOOPA==
+  dependencies:
+    deepmerge "1.3.2"
+    mitt "1.1.2"
+    svg-baker "^1.4.0"
+
+svg-baker@^1.4.0, svg-baker@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/svg-baker/-/svg-baker-1.4.1.tgz#6071edef6e99b12af87e655024c154d066e1ad2f"
+  integrity sha512-Y14nrVtN8IMYZ5K8yNlepdGwfAi0GClqaoSMTtYsQxFfaobtyDTM816lTWMA5tbbXDbih1frv7AGil54dtX6YA==
+  dependencies:
+    bluebird "^3.5.0"
+    clone "^2.1.1"
+    he "^1.1.1"
+    image-size "^0.5.1"
+    loader-utils "^1.1.0"
+    merge-options "1.0.1"
+    micromatch "3.1.0"
+    postcss "^5.2.17"
+    postcss-prefix-selector "^1.6.0"
+    posthtml-rename-id "^1.0"
+    posthtml-svg-mode "^1.0.3"
+    query-string "^4.3.2"
+    traverse "^0.6.6"
+
+svg-sprite-loader@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/svg-sprite-loader/-/svg-sprite-loader-4.1.6.tgz#ca03d51201e326c1c018389c81d5b0eb78dc01de"
+  integrity sha512-fVLDJ36GUfLmeZEB+RFq/OmiEThifZsQQ+8YSmbpOtyvlkLBbnGydYG6IHJehgbpy58898JyoHk+krd6C+6dXg==
+  dependencies:
+    bluebird "^3.5.0"
+    deepmerge "1.3.2"
+    domready "1.0.8"
+    escape-string-regexp "1.0.5"
+    html-webpack-plugin "^3.2.0"
+    loader-utils "^1.1.0"
+    svg-baker "^1.4.1"
+    svg-baker-runtime "1.4.1"
+    url-slug "2.0.0"
 
 svg-url-loader@^2.3.2:
   version "2.3.2"
@@ -10556,6 +10775,11 @@ tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -10705,6 +10929,11 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
   integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
 
+unidecode@0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/unidecode/-/unidecode-0.1.8.tgz#efbb301538bc45246a9ac8c559d72f015305053e"
+  integrity sha1-77swFTi8RSRqmsjFWdcvAVMFBT4=
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -10834,6 +11063,13 @@ url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-slug@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/url-slug/-/url-slug-2.0.0.tgz#a789d5aed4995c0d95af33377ad1d5c68d4d7027"
+  integrity sha1-p4nVrtSZXA2VrzM3etHVxo1NcCc=
+  dependencies:
+    unidecode "0.1.8"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -10849,7 +11085,7 @@ use@^3.1.0:
   dependencies:
     kind-of "^6.0.2"
 
-util-deprecate@^1.0.2, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
This PR adds an Icon component which is able to show any icon available in `@nimiq/style`.

The icon sprite is compiled during build time from the icons imported into the `Icon.vue` component. To not include all icons in every build, the list of icons can be reduced in the component by commenting out unwanted imports (just like in the `main.ts` file).

I had to do some webpack trickery to handle icon SVGs differently from regular SVGs (e.g. the Identicon SVG) and had to discover and use the `oneOf` rule separator for the webpack config.