### PR TITLE
Explicitly export icons from main.ts

### DIFF
--- a/src/components/Icons.ts
+++ b/src/components/Icons.ts
@@ -48,9 +48,6 @@ import Transfer from '@nimiq/style/src/icons/transfer.svg';
 import ViewOff from '@nimiq/style/src/icons/view-off.svg';
 import View from '@nimiq/style/src/icons/view.svg';
 
-/**
- * Comment out any unused icons here
- */
 // tslint:disable:variable-name
 export const AlertTriangleIcon = IconBase(AlertTriangle);
 export const ArrowLeftSmallIcon = IconBase(ArrowLeftSmall);

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,5 +25,40 @@ export { default as Wallet } from './components/Wallet.vue';
 export { default as WalletList } from './components/WalletList.vue';
 export { default as WalletMenu } from './components/WalletMenu.vue';
 
-// Comment out unused icons in the components/Icons.ts file
-export * from './components/Icons';
+export {
+    AlertTriangleIcon,
+    ArrowLeftSmallIcon,
+    ArrowLeftIcon,
+    ArrowRightSmallIcon,
+    ArrowRightIcon,
+    BrowserLoginIcon,
+    CaretRightSmallIcon,
+    CheckmarkIcon,
+    CloseIcon,
+    ContactsIcon,
+    CopyIcon,
+    DownloadIcon,
+    FaceNeutralIcon,
+    FaceSadIcon,
+    FireIcon,
+    GearIcon,
+    HexagonIcon,
+    InfoCircleIcon,
+    KeysIcon,
+    LedgerIcon,
+    LockLockedIcon,
+    LockUnlockedIcon,
+    LoginIcon,
+    MenuDotsIcon,
+    PaperEditIcon,
+    PlusCircleIcon,
+    QrCodeIcon,
+    QuestionmarkIcon,
+    ScanQrCodeIcon,
+    SettingsIcon,
+    ShredderIcon,
+    SkullIcon,
+    TransferIcon,
+    ViewOffIcon,
+    ViewIcon,
+} from './components/Icons';


### PR DESCRIPTION
For now just keeping this here for reference.

The idea was that now different builds trageting different apps can chose which icons to include in main.ts instead of in Icons.vue.
By not affecting the exports in Icons.vue, the build process (probably the linter only) would not complain
about missing exports anymore when checking files in the folder structure that are not actually part of the build but still checked for some reason.

However, unfortunately the icons that were commented out in `main.ts` still ended up in the bundle.
I experimented with setting `sideEffects` false on `vue-components` and `nimiq-style` and investigated whether the icons are bundled due to the call of the `IconBase` mixin.
However, the icons are bundled regardless of the `sideEffects` flag and omitting the `IconBase` mixin.

Note that this, fix should not be necessary anymore once we actually work on https://github.com/nimiq/vue-components/issues/8.