### PR TITLE
Cleanup type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "types/**/*"
   ],
   "scripts": {
-    "build": "vue-cli-service build --target lib --name NimiqVueComponents src/main.ts; vue-cli-service bundle-dts --name NimiqVueComponents",
+    "build": "vue-cli-service build --target lib --name NimiqVueComponents src/main.ts",
     "lint": "vue-cli-service lint",
     "storybook": "start-storybook -p 6006 -c .storybook -s ."
   },
@@ -36,7 +36,7 @@
     "qr-code": "github:nimiq/qr-encoder",
     "qr-scanner": "^1.1.1",
     "ts-loader": "^4.4.2",
-    "typescript": "^3.0.1",
+    "typescript": "^3.4.5",
     "vue-cli-plugin-ts-bundler": "^0.0.3",
     "vue-svg-loader": "^0.12.0",
     "vue-template-compiler": "^2.5.17"

--- a/src/components/QrCode.vue
+++ b/src/components/QrCode.vue
@@ -4,9 +4,6 @@
 
 <script lang="ts">
     import {Component, Prop, Vue, Watch} from 'vue-property-decorator';
-
-    // Only importing types as we're not using value QrEncoder. The actual implementation is lazy loaded via import.
-    // http://www.typescriptlang.org/docs/handbook/modules.html#optional-module-loading-and-other-advanced-loading-scenarios
     import QrEncoder from 'qr-code';
 
     /**
@@ -64,10 +61,10 @@
                 if (isValidColor(fill)) return true;
                 const isValidGradient = ((fill.type === 'linear-gradient' && fill.position.length === 4)
                     || (fill.type === 'radial-gradient' && fill.position.length === 6))
-                    && fill.position.every((coordinate) => typeof coordinate === 'number');
+                    && fill.position.every((coordinate: unknown) => typeof coordinate === 'number');
                 if (!isValidGradient) return false;
                 const hasValidGradientStops = fill.colorStops.length >= 2
-                    && fill.colorStops.every(([offset, color]) => typeof(offset) === 'number' && isValidColor(color));
+                    && fill.colorStops.every(([offset, color]: [unknown, unknown]) => typeof(offset) === 'number' && isValidColor(color));
                 return hasValidGradientStops;
             },
         })
@@ -100,10 +97,6 @@
         @Watch('size')
         private async _updateQrCode() {
             if (!this.data) return;
-            // lazy load qr encoder and let webpack chunk it
-            // tslint:disable-next-line variable-name no-shadowed-variable
-            const QrEncoder = (await import(/* webpackChunkName: 'qr-encoder' */ 'qr-code'))
-                .default;
             QrEncoder.render({
                 text: this.data,
                 radius: this.radius,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,6 @@
         "paths": {
             "@/*": [
                 "src/*"
-            ],
-            "@nimiq": [
-                "node_modules/@nimiq"
             ]
         },
         "lib": [

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
       "node_modules/**"
     ]
   },
+  "declaration": true,
   "rules": {
     "quotemark": [true, "single"],
     "indent": [true, "spaces", 4],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,1 @@
-/// <reference path="../dist/NimiqVueComponents.d.ts" />
-export * from 'NimiqVueComponents';
-
+export * from '../dist/src/main';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10770,10 +10770,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
-  integrity sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==
+typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
Make typescript generate types, instead of dts-bundle. Update typescript and add fix warnings.
Also remove lazy loading of qr-encoder to enable easy building of Safe (it's just 5kb).