### PR TITLE
tracking consent

### DIFF
--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -76,6 +76,7 @@ class TrackingConsent extends Vue {
         validator: (options) => 'setSiteId' in options,
         default: () => ({
             setTrackerUrl: TrackingConsent.DEFAULT_TRACKER_URL,
+            trackPageView: null,
         }),
     })
     public options: {
@@ -206,6 +207,24 @@ class TrackingConsent extends Vue {
                 }
             }]);
         });
+    }
+
+    /**
+     * trackPageView - allow you to track a new page view. Usefull for single-page apps that use history manipulation
+     *
+     * @param {number} generationTimeMs - Time that took the new route to load. Usefull if lazy-loading routes
+     */
+    public static trackPageView(
+        options?: {
+            generationTimeMs?: number,
+            customUrl?: string,
+        },
+    ) {
+        if (options.customUrl) TrackingConsent._paq.push(['setCustomUrl', options.customUrl]);
+
+        TrackingConsent._paq.push(['deleteCustomVariables', 'page']);
+        TrackingConsent._paq.push(['setGenerationTimeMs', options.generationTimeMs || 0]);
+        TrackingConsent._paq.push(['trackPageView']);
     }
 
     private static _setCookie(
@@ -372,9 +391,10 @@ class TrackingConsent extends Vue {
         }
 
         /* set setTrackerUrl to default value if not set */
-        if (!this.options.setTrackerUrl) {
-            this.options.setTrackerUrl = TrackingConsent.DEFAULT_TRACKER_URL;
-        }
+        if (!this.options.setTrackerUrl) this.options.setTrackerUrl = TrackingConsent.DEFAULT_TRACKER_URL;
+
+        /* set trackPageView if not set, to track the first page view */
+        if (!this.options.trackPageView) this.options.trackPageView = null;
 
         /* Cycle through options and set them */
         Object.keys(this.options).forEach((k) => {

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -122,7 +122,7 @@ class TrackingConsent extends Vue {
         type: String,
         default: () => TrackingConsent.DEFAULT_GEOIP_SERVER_URL,
     })
-    public geoIpServer: string;
+    public geoIpServer: string | null;
 
     private uiRequired: boolean = false;
     private isOutsideEEA: boolean = false;
@@ -328,18 +328,20 @@ class TrackingConsent extends Vue {
             return;
         }
 
-        /* Automatically track stats if user is not in the EU continent  */
-        const geoIpResponse = await fetch(this.geoIpServer);
-        if (geoIpResponse.status !== 200) {
-            console.warn('TrackingConsent: Failed to contact geoip server');
-            return;
-        }
-        const geoIpInfo = await geoIpResponse.json();
-        if (geoIpInfo.continent !== 'EU' && !['NO', 'LI', 'IS'].includes(geoIpInfo.country)) { /* EU / EEA */
-            this.uiRequired = false;
-            this.isOutsideEEA = true;
-            TrackingConsent._paq.push(['setCookieConsentGiven']);
-            return;
+        if (this.geoIpServer) {
+            /* Automatically track stats if user is not in the EU continent  */
+            const geoIpResponse = await fetch(this.geoIpServer);
+            if (geoIpResponse.status !== 200) {
+                console.warn('TrackingConsent: Failed to contact geoip server');
+                return;
+            }
+            const geoIpInfo = await geoIpResponse.json();
+            if (geoIpInfo.continent !== 'EU' && !['NO', 'LI', 'IS'].includes(geoIpInfo.country)) { /* EU / EEA */
+                this.uiRequired = false;
+                this.isOutsideEEA = true;
+                TrackingConsent._paq.push(['setCookieConsentGiven']);
+                return;
+            }
         }
 
         this.uiRequired = true;

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -191,6 +191,16 @@ class TrackingConsent extends Vue {
         TrackingConsent._paq.push(obj);
     }
 
+    /**
+     * execFunction - allow you to execute a function in matomo's scope, where `this` is Matomo's tracker object
+     *
+     * Docs: https://developer.matomo.org/guides/tracking-javascript-guide
+     * API ref: https://developer.matomo.org/guides/tracking-javascript
+     */
+    public static execFunction(fn: () => void) {
+        TrackingConsent._paq.push([fn]);
+    }
+
     private static _setCookie(
         cookieName: string,
         cookieValue: string,

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="tracking-consent"
-        :class="[ theme, safariFix ]"
+        :class="[ theme ]"
         v-if="uiRequired && uiAllowed"
     >
         <div class="content nq-shadow">
@@ -251,29 +251,6 @@ class TrackingConsent extends Vue {
         this._checkUiRequired();
     }
 
-    private mounted() {
-        /* Safari IOS style fix */
-        const ua = window.navigator.userAgent;
-        const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-        const webkit = !!ua.match(/WebKit/i);
-        const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
-
-        if (iOSSafari) {
-            let majorVersion = null;
-
-            if (/iP(hone|od|ad)/.test(navigator.platform)) {
-                const match = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
-                majorVersion = parseInt(match[1], 10);
-            }
-
-            if (majorVersion >= 13) {
-                this.safariFix = 'ios-safari-13-fix';
-            } else if (majorVersion >= 12) {
-                this.safariFix = 'ios-safari-12-fix';
-            }
-        }
-    }
-
     private destroyed() {
         /* Remove the event watching for consent changes on tab / window focus */
         document.removeEventListener('visibilitychange', this._onVisibilityChange);
@@ -449,14 +426,6 @@ export default TrackingConsent;
 
         .tracking-consent {
             bottom: 0;
-        }
-
-        .tracking-consent.ios-safari-13-fix {
-            bottom: 74px;
-        }
-
-        .tracking-consent.ios-safari-12-fix {
-            bottom: 34px;
         }
 
         .button-group {

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -1,25 +1,26 @@
 <template>
-    <div
-        class="tracking-consent nq-shadow"
+    <div class="tracking-consent"
         :class="[ theme, safariFix ]"
         v-if="uiRequired && uiAllowed"
     >
-        {{ text.main }}
-        <div class="button-group">
-            <button
-                class="nq-button-pill light-blue"
-                @click="allowUsageData"
-            >{{ text.yes }}</button>
-            <button
-                class="nq-button-s"
-                @click="denyConsent"
-                :class="{ inverse: theme === constructor.Themes.DARK }"
-            >{{ text.no }}</button>
-            <button
-                class="nq-button-s"
-                @click="allowBrowserData"
-                :class="{ inverse: theme === constructor.Themes.DARK }"
-            >{{ text.browserOnly }}</button>
+        <div class="content nq-shadow">
+            {{ text.main }}
+            <div class="button-group">
+                <button
+                    class="nq-button-pill light-blue"
+                    @click="allowUsageData"
+                >{{ text.yes }}</button>
+                <button
+                    class="nq-button-s"
+                    @click="denyConsent"
+                    :class="{ inverse: theme === constructor.Themes.DARK }"
+                >{{ text.no }}</button>
+                <button
+                    class="nq-button-s"
+                    @click="allowBrowserData"
+                    :class="{ inverse: theme === constructor.Themes.DARK }"
+                >{{ text.browserOnly }}</button>
+            </div>
         </div>
     </div>
 </template>
@@ -402,23 +403,28 @@ export default TrackingConsent;
         position: fixed;
         bottom: 2rem;
         z-index: 900;
+        display: flex;
+        justify-content: center;
+        width: 100%;
+    }
 
-        padding: 1.5rem;
-
+    .content {
         display: flex;
         align-items: center;
         justify-content: space-between;
+
+        padding: 1.5rem;
 
         border-radius: 1rem;
         font-size: 2rem;
     }
 
-    .tracking-consent.light {
+    .light .content {
         background: white;
         color: var(--nimiq-blue);
     }
 
-    .tracking-consent.dark {
+    .dark .content {
         background: var(--nimiq-blue);
         color: white;
     }
@@ -433,14 +439,16 @@ export default TrackingConsent;
     }
 
     @media (max-width: 860px) {
-        .tracking-consent {
+        .content {
             flex-direction: column;
             align-items: flex-start;
-            width: 100%;
-            bottom: 0;
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
             padding: 2.5rem;
+        }
+
+        .tracking-consent {
+            bottom: 0;
         }
 
         .tracking-consent.ios-safari-13-fix {

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -33,7 +33,9 @@ interface Consent {
     allowsBrowserData?: boolean;
     allowsUsageData?: boolean;
 }
-
+/**
+ * TrackinConsent Component - used to setup Matomo tracking in a vue-based project
+ */
 @Component
 class TrackingConsent extends Vue {
     @Prop({
@@ -74,21 +76,21 @@ class TrackingConsent extends Vue {
     @Prop({
         type: Object,
         default: () => ({
-            setTrackerUrl: TrackingConsent.DEFAULT_MATOMO_URL + 'nimiq.php',
+            setTrackerUrl: TrackingConsent.DEFAULT_TRACKER_URL,
         }),
     })
     public options: {
-        setSiteId: string, /* 3 for safe.nimiq.com ? */
+        setSiteId: number, /* 3 for safe.nimiq.com ? */
         setTrackerUrl: string
         addDownloadExtensions?: string,
         trackPageView?: boolean,
         enableLinkTracking?: boolean,
-        [k: string]: string | boolean,
+        [k: string]: number | string | boolean,
     };
 
     @Prop({
         type: String,
-        default: () => TrackingConsent.DEFAULT_MATOMO_URL + 'nimiq.js',
+        default: () => TrackingConsent.DEFAULT_TRACKING_URL,
     })
     public trackingScriptUrl: string;
 
@@ -230,7 +232,7 @@ class TrackingConsent extends Vue {
         }
 
         /* Check for consent changes on tab / window focus */
-        document.addEventListener('visibilitychange', this._onVisibilityChange);
+        window.addEventListener('focus', this._onVisibilityChange);
 
         /* Add to the TrackingConsent instances list */
         TrackingConsent._instances.add(this);
@@ -253,7 +255,7 @@ class TrackingConsent extends Vue {
 
     private destroyed() {
         /* Remove the event watching for consent changes on tab / window focus */
-        document.removeEventListener('visibilitychange', this._onVisibilityChange);
+        window.removeEventListener('focus', this._onVisibilityChange);
 
         /* Remove from the TrackingConsent instances list */
         TrackingConsent._instances.delete(this);
@@ -335,6 +337,11 @@ class TrackingConsent extends Vue {
             localStorage.removeItem('referrer');
         }
 
+        /* set setTrackerUrl to default value if not set */
+        if (!this.options.setTrackerUrl) {
+            this.options.setTrackerUrl = TrackingConsent.DEFAULT_TRACKER_URL;
+        }
+
         /* Cycle through options and set them */
         Object.keys(this.options).forEach((k) => {
             const option = this.options[k];
@@ -352,8 +359,6 @@ class TrackingConsent extends Vue {
         script.src = this.trackingScriptUrl;
         script.setAttribute('matomo', '');
         nextScript.parentNode.insertBefore(script, nextScript);
-
-        console.log('TrackingConsent: Matomo initialized and script added');
     }
 }
 
@@ -370,6 +375,9 @@ namespace TrackingConsent { // tslint:disable-line:no-namespace
 
     export const COOKIE_STORAGE_KEY = 'tracking-consent';
     export const DEFAULT_MATOMO_URL = '//stats.nimiq-network.com/';
+
+    export const DEFAULT_TRACKER_URL = DEFAULT_MATOMO_URL + 'matomo.php';
+    export const DEFAULT_TRACKING_URL = DEFAULT_MATOMO_URL + 'matomo.js';
 }
 
 export default TrackingConsent;

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -4,7 +4,7 @@
         :class="[ theme, safariFix ]"
         v-if="uiRequired && uiAllowed"
     >
-        {{ text.main }} ❤️
+        {{ text.main }}
         <div class="button-group">
             <button
                 class="nq-button-pill light-blue"
@@ -26,6 +26,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import I18nMixin from '../i18n/I18nMixin';
 
 interface Consent {
     allowsBrowserData?: boolean;
@@ -37,17 +38,22 @@ class TrackingConsent extends Vue {
     @Prop({
         type: Object,
         default:  () => ({
-            main: 'Help Nimiq improve by sharing anonymized usage data. Thank you!',
-            yes: 'Yes',
-            no: 'No',
+            get main() {
+                return I18nMixin.$t(
+                    'TrackingConsent',
+                    'Help Nimiq improve by sharing anonymized usage data. Thank you! ❤️',
+                );
+            },
+            get yes() { return I18nMixin.$t('TrackingConsent', 'Yes'); },
+            get no() { return I18nMixin.$t('TrackingConsent', 'No'); },
             browserOnly: 'Browser-info only',
         }),
-        validator: (value) => (
-            value && typeof value === 'object' &&
-            value.no && typeof value.no === 'string' && value.no.length &&
-            value.yes && typeof value.yes === 'string' && value.yes.length &&
-            value.main && typeof value.main === 'string' && value.main.length &&
-            value.browserOnly && typeof value.browserOnly === 'string' && value.browserOnly.length
+        validator: (text) => (
+            text && typeof text === 'object' &&
+            text.no && typeof text.no === 'string' && text.no.length &&
+            text.yes && typeof text.yes === 'string' && text.yes.length &&
+            text.main && typeof text.main === 'string' && text.main.length &&
+            text.browserOnly && typeof text.browserOnly === 'string' && text.browserOnly.length
         ),
     })
     public text: {

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -3,16 +3,24 @@
         id="tracking-consent"
         class="tracking-consent-banner nq-shadow"
         :class="theme"
+        v-if="!consentKnown"
     >
         {{ text.main }} ❤️
         <div class="button-group">
             <button
+                class="nq-button-pill light-blue"
+                @click="allowsConsent"
+            >{{ text.yes }}</button>
+            <button
                 class="nq-button-s"
+                @click="denyConsent"
                 :class="{ inverse: theme === 'dark' }"
             >{{ text.no }}</button>
             <button
-                class="nq-button-pill light-blue"
-            >{{ text.yes }}</button>
+                class="nq-button-s"
+                @click="allowsBrowserData"
+                :class="{ inverse: theme === 'dark' }"
+            >{{ text.browserOnly }}</button>
         </div>
     </div>
 </template>
@@ -20,28 +28,34 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-const STORAGE_KEYS = ['tracking-consent', 'tracking-consensus'];
+interface Consents {
+    allowsBrowserData?: boolean;
+    allowsUsageData?: boolean;
+}
 
 @Component
-export default class TrackingConsent extends Vue {
+class TrackingConsent extends Vue {
     @Prop({
         type: Object,
         default:  () => ({
             main: 'Help Nimiq improve by sharing anonymized usage data. Thank you!',
             yes: 'Yes',
             no: 'No',
+            browserOnly: 'Browser-info only',
         }),
         validator: (value) => (
             value && typeof value === 'object' &&
-            value.main && typeof value.main === 'string' && value.main.length &&
+            value.no && typeof value.no === 'string' && value.no.length &&
             value.yes && typeof value.yes === 'string' && value.yes.length &&
-            value.no && typeof value.no === 'string' && value.no.length
+            value.main && typeof value.main === 'string' && value.main.length &&
+            value.browserOnly && typeof value.browserOnly === 'string' && value.browserOnly.length
         ),
     })
-    private text!: {
+    private text: {
         main: string,
         yes: string,
         no: string,
+        browserOnly: string,
     };
 
     @Prop({
@@ -49,8 +63,200 @@ export default class TrackingConsent extends Vue {
         default: 'light',
         validator: (theme) => ['dark', 'light'].includes(theme),
     })
-    public theme!: string;
+    private theme: string;
+
+    @Prop({
+        type: String,
+        default: 'nimiq.com',
+    })
+    private domain: string;
+
+    @Prop({
+        type: Object,
+        default: () => ({
+            setTrackerUrl: TrackingConsent.MATOMO_URL + 'nimiq.php',
+        }),
+    })
+    private options: {
+        setSiteId: string, // 3 for safe.nimiq.com ?
+        setTrackerUrl: string
+        addDownloadExtensions?: string,
+        trackPageView?: boolean,
+        enableLinkTracking?: boolean,
+        [k: string]: string | boolean,
+    };
+
+    @Prop({
+        type: String,
+        default: 'nimiq.js',
+    })
+    private tagManagerScript: string;
+
+    private consentKnown: boolean = false;
+    private _storage: Consents;
+
+    private async mounted() {
+        if (!window.startTime) {
+            window.startTime = (new Date().getTime());
+        }
+
+        if (this.consents.allowsBrowserData || this.consents.allowsUsageData) {
+            this._initMatomo();
+        }
+
+        const geoIpResponse = await fetch(TrackingConsent.GEOIP_SERVER);
+        if (geoIpResponse.status !== 200) {
+            throw new Error('Failed to contact geoip server');
+        }
+        const geoIpInfo = await geoIpResponse.json();
+        if (geoIpInfo.continent !== 'EU') {
+            this.allowsConsent();
+        }
+    }
+
+    public get consents(): Consents {
+        if (this._storage) {
+            return this._storage;
+        }
+
+        const cookie = this._getCookie(TrackingConsent.STORAGE_KEYS.MAIN);
+        if (cookie) {
+            this._storage = JSON.parse(cookie);
+            return this._storage;
+        }
+
+        const localStoredConsent =
+            localStorage.getItem(TrackingConsent.STORAGE_KEYS.MAIN) ||
+            localStorage.getItem(TrackingConsent.STORAGE_KEYS.SECOND);
+
+        if (localStoredConsent) {
+            this._storage = JSON.parse(localStoredConsent);
+            this._setCookie(TrackingConsent.STORAGE_KEYS.MAIN, localStoredConsent);
+            localStorage.removeItem(TrackingConsent.STORAGE_KEYS.MAIN);
+            localStorage.removeItem(TrackingConsent.STORAGE_KEYS.SECOND);
+            return this._storage;
+        }
+
+        return {};
+    }
+
+    public trackEvent(
+        category: string,
+        action: string,
+        name?: string,
+        value?: string | number,
+    ): void {
+        const _paq = window.paq || [];
+        const obj: Array<string | number> = [category, action];
+
+        if (name) {
+            obj.push(name);
+        }
+        if (value) {
+            obj.push(value);
+        }
+
+        _paq.push(obj);
+    }
+
+    private denyConsent(): void {
+        this._setConsent({ allowsUsageData: false, allowsBrowserData: false });
+    }
+
+    private allowsConsent(): void {
+        this._setConsent({ allowsUsageData: true, allowsBrowserData: true });
+        this._initMatomo();
+    }
+
+    private allowsBrowserData(): void {
+        this._setConsent({ allowsBrowserData: true });
+        this._initMatomo();
+    }
+
+    private _setConsent(consent: Consents): void {
+        this._setCookie(TrackingConsent.STORAGE_KEYS.MAIN, JSON.stringify(consent));
+        this.consentKnown = true;
+    }
+
+    private _initMatomo() {
+        // initialize matomo
+        const _paq = window._paq || [];
+        const _mtm = window._mtm || [];
+
+        // set mtm start
+        _mtm.push({
+            'mtm.startTime': window.startTime,
+            'event': 'mtm.Start',
+        });
+
+        // Get referrer from localstorage
+        const referrer = localStorage.getItem('referrer');
+        if (referrer) {
+            _paq.push(['setReferrerUrl', decodeURIComponent(referrer)]);
+            localStorage.removeItem('referrer');
+        }
+
+        // Cycle through options and set them
+        Object.keys(this.options).forEach((k) => {
+            const option = this.options[k];
+
+            if (option) {
+                _paq.push(typeof option === 'boolean' ? [k] : [k, option]);
+            }
+        });
+
+        // append script
+        (function() {
+            const g = document.createElement('script');
+            const s = document.getElementsByTagName('script')[0];
+            g.type = 'text/javascript'; g.async = true; g.defer = true;
+            g.src = TrackingConsent.MATOMO_URL + this.tagManagerScript;
+            s.parentNode.insertBefore(g, s);
+        })();
+    }
+
+    private _setCookie(
+        cookieName: string,
+        cookieValue: string,
+        expirationDays?: number,
+    ): void {
+        const cookie = [cookieName + '=' + cookieValue];
+
+        if (expirationDays) {
+            const date = new Date();
+            date.setTime(date.getTime() + (expirationDays * 24 * 60 * 60 * 1000));
+
+            cookie.push(';expires=' + date.toUTCString());
+        }
+
+        cookie.push('path=/');
+        cookie.push('domain=' + this.domain);
+
+        document.cookie = cookie.join(';');
+    }
+
+    private _getCookie(cookieName: string): string {
+        return document.cookie.split('; ').map((c) => {
+            const i = c.indexOf('=');
+            const key = c.substring(0, i);
+            const value = c.substring(i);
+
+            return [key, value];
+        }).reduce((acc, cur) => (acc[cur[0]] = cur[1], acc), {})[cookieName] || '';
+    }
 }
+
+namespace TrackingConsent { // tslint:disable-line:no-namespace
+    export enum STORAGE_KEYS {
+        MAIN = 'tracking-consent',
+        SECOND = 'tracking-consensus',
+    }
+
+    export const GEOIP_SERVER = 'https://geoip.nimiq-network.com:8443/v1/locate';
+    export const MATOMO_URL = '//stats.nimiq-network.com/';
+}
+
+export default TrackingConsent;
 </script>
 
 <style scoped>
@@ -84,7 +290,7 @@ export default class TrackingConsent extends Vue {
         display: flex;
     }
 
-    .button-group button:nth-child(2) {
+    .button-group button:not(:first-child) {
         margin-left: 1rem;
     }
 

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         class="tracking-consent nq-shadow"
-        :class="theme"
+        :class="[ theme, safariFix ]"
         v-if="uiRequired && uiAllowed"
     >
         {{ text.main }} ❤️
@@ -118,6 +118,7 @@ class TrackingConsent extends Vue {
 
     private static _instances: Set<TrackingConsent> = new Set();
     private uiRequired: boolean = false;
+    private safariFix: string = '';
 
     public static get _paq() {
         if (!window._paq || !Array.isArray(window._paq)) {
@@ -241,6 +242,29 @@ class TrackingConsent extends Vue {
 
         /* check if the UI is required */
         this._checkUiRequired();
+    }
+
+    private mounted() {
+        /* Safari IOS style fix */
+        const ua = window.navigator.userAgent;
+        const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+        const webkit = !!ua.match(/WebKit/i);
+        const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+
+        if (iOSSafari) {
+            let majorVersion = null;
+
+            if (/iP(hone|od|ad)/.test(navigator.platform)) {
+                const match = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+                majorVersion = parseInt(match[1], 10);
+            }
+
+            if (majorVersion >= 13) {
+                this.safariFix = 'ios-safari-13-fix';
+            } else if (majorVersion >= 12) {
+                this.safariFix = 'ios-safari-12-fix';
+            }
+        }
     }
 
     private destroyed() {
@@ -411,6 +435,14 @@ export default TrackingConsent;
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
             padding: 2.5rem;
+        }
+
+        .tracking-consent.ios-safari-13-fix {
+            bottom: 74px;
+        }
+
+        .tracking-consent.ios-safari-12-fix {
+            bottom: 34px;
         }
 
         .button-group {

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -1,0 +1,107 @@
+<template>
+    <div
+        id="tracking-consent"
+        class="tracking-consent-banner nq-shadow"
+        :class="theme"
+    >
+        {{ text.main }} ❤️
+        <div class="button-group">
+            <button
+                class="nq-button-s"
+                :class="{ inverse: theme === 'dark' }"
+            >{{ text.no }}</button>
+            <button
+                class="nq-button-pill light-blue"
+            >{{ text.yes }}</button>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+const STORAGE_KEYS = ['tracking-consent', 'tracking-consensus'];
+
+@Component
+export default class TrackingConsent extends Vue {
+    @Prop({
+        type: Object,
+        default:  () => ({
+            main: 'Help Nimiq improve by sharing anonymized usage data. Thank you!',
+            yes: 'Yes',
+            no: 'No',
+        }),
+        validator: (value) => (
+            value && typeof value === 'object' &&
+            value.main && typeof value.main === 'string' && value.main.length &&
+            value.yes && typeof value.yes === 'string' && value.yes.length &&
+            value.no && typeof value.no === 'string' && value.no.length
+        ),
+    })
+    private text!: {
+        main: string,
+        yes: string,
+        no: string,
+    };
+
+    @Prop({
+        type: String,
+        default: 'light',
+        validator: (theme) => ['dark', 'light'].includes(theme),
+    })
+    public theme!: string;
+}
+</script>
+
+<style scoped>
+    .tracking-consent-banner {
+        position: fixed;
+        bottom: 2rem;
+        z-index: 900;
+
+        padding: 1.5rem;
+
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        border-radius: 1rem;
+        font-size: 2rem;
+    }
+
+    .tracking-consent-banner.light {
+        background: white;
+        color: var(--nimiq-blue);
+    }
+
+    .tracking-consent-banner.dark {
+        background: var(--nimiq-blue);
+        color: white;
+    }
+
+    .button-group {
+        margin-left: 3rem;
+        display: flex;
+    }
+
+    .button-group button:nth-child(2) {
+        margin-left: 1rem;
+    }
+
+    @media (max-width: 860px) {
+        .tracking-consent-banner {
+            flex-direction: column;
+            align-items: flex-start;
+            width: 100%;
+            bottom: 0;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+            padding: 2.5rem;
+        }
+
+        .button-group {
+            margin-left: 0;
+            margin-top: 16px;
+        }
+    }
+</style>

--- a/src/components/TrackingConsent.vue
+++ b/src/components/TrackingConsent.vue
@@ -75,6 +75,7 @@ class TrackingConsent extends Vue {
     })
     public theme: string;
 
+    /** API reference: https://developer.matomo.org/guides/tracking-javascript#configuration-of-the-tracker-object */
     @Prop({
         type: Object,
         default: () => ({
@@ -85,10 +86,7 @@ class TrackingConsent extends Vue {
     public options: {
         setSiteId: number,
         setTrackerUrl?: string
-        addDownloadExtensions?: string,
-        trackPageView?: boolean,
-        enableLinkTracking?: boolean,
-        [k: string]: number | string | boolean,
+        [k: string]: null | boolean | number | string | string[],
     };
 
     @Prop({
@@ -370,9 +368,7 @@ class TrackingConsent extends Vue {
         Object.keys(this.options).forEach((k) => {
             const option = this.options[k];
 
-            if (option) {
-                TrackingConsent._paq.push(typeof option === 'boolean' ? [k] : [k, option]);
-            }
+            TrackingConsent._paq.push(option === null ? [k] : [k, option]);
         });
 
         /* append script */

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Grant camera access when asked."
 msgstr ""
 
-#: src/components/TrackingConsent.vue:42
+#: src/components/TrackingConsent.vue:43
 msgid "Help Nimiq improve by sharing anonymized usage data. Thank you! ❤️"
 msgstr ""
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Nimiq provides this service free of charge."
 msgstr ""
 
-#: src/components/TrackingConsent.vue:48
+#: src/components/TrackingConsent.vue:49
 msgid "No"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Vendor crypto markup"
 msgstr ""
 
-#: src/components/TrackingConsent.vue:47
+#: src/components/TrackingConsent.vue:48
 msgid "Yes"
 msgstr ""
 

--- a/src/i18n/en.po
+++ b/src/i18n/en.po
@@ -103,6 +103,10 @@ msgstr ""
 msgid "Grant camera access when asked."
 msgstr ""
 
+#: src/components/TrackingConsent.vue:42
+msgid "Help Nimiq improve by sharing anonymized usage data. Thank you! ❤️"
+msgstr ""
+
 #: src/components/Timer.vue:93
 msgid "hour"
 msgstr ""
@@ -155,6 +159,10 @@ msgstr ""
 
 #: src/components/PaymentInfoLine.vue:60
 msgid "Nimiq provides this service free of charge."
+msgstr ""
+
+#: src/components/TrackingConsent.vue:48
+msgid "No"
 msgstr ""
 
 #: src/components/SendTx.vue:108
@@ -252,6 +260,10 @@ msgstr ""
 
 #: src/components/PaymentInfoLine.vue:40
 msgid "Vendor crypto markup"
+msgstr ""
+
+#: src/components/TrackingConsent.vue:47
+msgid "Yes"
 msgstr ""
 
 #: src/components/PaymentInfoLine.vue:281

--- a/src/i18n/fr.po
+++ b/src/i18n/fr.po
@@ -120,6 +120,10 @@ msgstr "Retour"
 msgid "Grant camera access when asked."
 msgstr "Accordez l'accès à la caméra lorsque cela vous est demandé."
 
+#: src/components/TrackingConsent.vue:42
+msgid "Help Nimiq improve by sharing anonymized usage data. Thank you! ❤️"
+msgstr ""
+
 #: src/components/Timer.vue:93
 msgid "hour"
 msgstr "heure"
@@ -171,6 +175,10 @@ msgstr "frais de réseau"
 #: src/components/PaymentInfoLine.vue:60
 msgid "Nimiq provides this service free of charge."
 msgstr "Nimiq fournit ce service gratuitement."
+
+#: src/components/TrackingConsent.vue:48
+msgid "No"
+msgstr ""
 
 #: src/components/SendTx.vue:108
 msgid "Open settings"
@@ -267,6 +275,10 @@ msgstr "Crypto-remise"
 #: src/components/PaymentInfoLine.vue:40
 msgid "Vendor crypto markup"
 msgstr "Crypto-premium"
+
+#: src/components/TrackingConsent.vue:47
+msgid "Yes"
+msgstr ""
 
 #: src/components/PaymentInfoLine.vue:281
 msgid ""

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ export { default as QrScanner } from './components/QrScanner.vue';
 export { default as SelectBar } from './components/SelectBar.vue';
 export { default as SmallPage } from './components/SmallPage.vue';
 export { default as Timer } from './components/Timer.vue';
+export { default as TrackingConsent } from './components/TrackingConsent.vue';
 export { default as Tooltip } from './components/Tooltip.vue';
 export { default as Wallet } from './components/Wallet.vue';
 

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -831,7 +831,8 @@ storiesOf('Components', module)
         return {
             components: { TrackingConsent },
             data: () => ({
-                theme: 'dark'
+                theme: 'dark',
+                uiallowed: true
             }),
             template: windowTemplate(`
                 <label>
@@ -842,7 +843,16 @@ storiesOf('Components', module)
                     Light theme
                     <input type="radio" v-model="theme" value="light"/>
                 </label>
-                <TrackingConsent :theme="theme"/>
+                <br />
+                <label>
+                    Ui Allowed
+                    <input type="radio" v-model="uiallowed" :value="true"/>
+                </label>
+                <label>
+                    Ui Not Allowed
+                    <input type="radio" v-model="uiallowed" :value="false"/>
+                </label>
+                <TrackingConsent :theme="theme" :uiAllowed="uiallowed"/>
             `)
         };
     })

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -832,7 +832,8 @@ storiesOf('Components', module)
             components: { TrackingConsent },
             data: () => ({
                 theme: 'dark',
-                uiallowed: true
+                uiallowed: true,
+                setSiteId: 68,
             }),
             template: windowTemplate(`
                 <label>
@@ -852,7 +853,16 @@ storiesOf('Components', module)
                     Ui Not Allowed
                     <input type="radio" v-model="uiallowed" :value="false"/>
                 </label>
-                <TrackingConsent :theme="theme" :uiAllowed="uiallowed"/>
+                <br />
+                <label>
+                    Matomo Site ID (required, 68 is demo)
+                    <input type="number" v-model="setSiteId" />
+                </label>
+                <TrackingConsent
+                    :theme="theme"
+                    :uiAllowed="uiallowed"
+                    :options="{ setSiteId, trackPageView: null }"
+                />
             `)
         };
     })

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -33,6 +33,7 @@ import PageHeader from '../components/PageHeader.vue';
 import PageBody from '../components/PageBody.vue';
 import PageFooter from '../components/PageFooter.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
+import TrackingConsent from '../components/TrackingConsent.vue';
 import * as Icons from '../components/Icons';
 
 import '@nimiq/style/nimiq-style.min.css';
@@ -824,6 +825,25 @@ storiesOf('Components', module)
     <page-footer>Page footer</page-footer>
 </small-page>
 `),
+        };
+    })
+    .add('TrackingConsent', () => {
+        return {
+            components: { TrackingConsent },
+            data: () => ({
+                theme: 'dark'
+            }),
+            template: windowTemplate(`
+                <label>
+                    Dark theme
+                    <input type="radio" v-model="theme" value="dark"/>
+                </label>
+                <label>
+                    Light theme
+                    <input type="radio" v-model="theme" value="light"/>
+                </label>
+                <TrackingConsent :theme="theme"/>
+            `)
         };
     })
     .add('Timer', () => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     },
     "include": [
         "types/svg.d.ts",
-        "src/main.ts" // Must be included for TSLint to work
+        "src/main.ts", // Must be included for TSLint to work
         // "src/**/*.ts",
         // "src/**/*.tsx",
         // "src/**/*.vue",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "include": [
         "types/svg.d.ts",
         "src/main.ts", // Must be included for TSLint to work
+        "types/TrackingConsent.d.ts",
         // "src/**/*.ts",
         // "src/**/*.tsx",
         // "src/**/*.vue",

--- a/types/TrackingConsent.d.ts
+++ b/types/TrackingConsent.d.ts
@@ -1,0 +1,5 @@
+declare interface Window {
+    startTime: number,
+    _mtm: any[],
+    _paq: any[],
+}


### PR DESCRIPTION
This Pr add the TrackingConsent component, used to setup matomo tracking easily.

You can try it locally in the wallet, branch `matheo/matomo_tracking`, or using "Curd's Fancy Deployment Selector".