### PR TITLE
Tooltip improvements

### DIFF
--- a/src/components/SendTx.vue
+++ b/src/components/SendTx.vue
@@ -209,24 +209,31 @@ import { Utf8Tools, BrowserDetection } from '@nimiq/utils';
         @Prop({type: String, default: ''}) public message!: string;
         @Prop({type: Number, default: 0}) public validityStartHeight!: number;
 
-        public $refs: {
-            accountDetails?: AccountDetails,
-            amountWithFee?: AmountWithFee,
-            messageInput?: LabelInput,
-            feeSetter?: SelectBar,
-            address?: AddressInput,
-        };
+        // Note that these refs are optional but can not be types as such with a ? as 'undefined' is not assignable to
+        // type 'Element | Element[] | Vue | Vue[]'.
+        public $refs: ({} | {
+            accountDetails: AccountDetails,
+        }) & ({} | {
+            amountWithFee: AmountWithFee,
+        }) & ({} | {
+            messageInput: LabelInput,
+        }) & ({} | {
+            feeSetter: SelectBar,
+        }) & ({} | {
+            address: AddressInput,
+        });
 
         public focus(dontFocusOnMobile = false) {
             if (dontFocusOnMobile && BrowserDetection.isMobile()) return;
             Vue.nextTick(() => { // Await updated DOM
-                if (this.$refs.accountDetails) {
+                if ('accountDetails' in this.$refs && this.$refs.accountDetails) {
                     this.$refs.accountDetails.focus();
-                } else if (this.$refs.address) {
+                } else if ('address' in this.$refs && this.$refs.address) {
                     this.$refs.address.focus();
-                } else if (this.$refs.amountWithFee && (!this.liveAmountAndFee.amount || this.liveExtraData)) {
+                } else if ('amountWithFee' in this.$refs && this.$refs.amountWithFee
+                    && (!this.liveAmountAndFee.amount || this.liveExtraData)) {
                     this.$refs.amountWithFee.focus();
-                } else if (this.$refs.messageInput) {
+                } else if ('messageInput' in this.$refs && this.$refs.messageInput) {
                     this.$refs.messageInput.focus();
                 }
             });
@@ -386,8 +393,9 @@ import { Utf8Tools, BrowserDetection } from '@nimiq/utils';
         }
 
         private setFee() {
+            if (!('feeSetter' in this.$refs)) return; // should never happen
             this.optionsOpened = false;
-            this.feeLunaPerByte = this.$refs!.feeSetter.value;
+            this.feeLunaPerByte = this.$refs.feeSetter.value;
             this.liveAmountAndFee.fee = this.fee;
             this.focus(true);
         }

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -69,9 +69,12 @@ class Tooltip extends Vue {
 
     // Typing of $refs and $el, in order to not having to cast it everywhere.
     public $refs!: {
-        tooltipBox?: HTMLDivElement,
         tooltipTrigger: HTMLAnchorElement,
-    };
+    } & ({} | {
+        // tooltipBox is optional but can not be types as such with a ? as 'undefined' is not assignable to type
+        // 'Element | Element[] | Vue | Vue[]'
+        tooltipBox: HTMLDivElement,
+    });
     public $el: HTMLElement;
 
     private verticalPosition: Tooltip.VerticalPosition | null = null;
@@ -186,7 +189,7 @@ class Tooltip extends Vue {
 
         // make sure that tooltipBox is created, then update measurements
         await Vue.nextTick();
-        if (!this.isShown) return; // tooltip not visible anymore?
+        if (!this.isShown || !('tooltipBox' in this.$refs && this.$refs.tooltipBox)) return; // not visible anymore?
         // here we need the quick reflow to avoid that the visible tooltip gets rendered at the wrong position,
         // potentially causing scroll bars
         this.height = this.$refs.tooltipBox.offsetHeight;

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -132,7 +132,10 @@ export default class Tooltip extends Vue {
                 return;
             }
             // position tooltip such that it best fits reference element
-            if (this.reference.$el.scrollTop < this.$el.offsetTop - this.height) {
+            const triggerBoundingRect = this.$refs.tooltipTrigger.getBoundingClientRect();
+            const referenceBoundingRect = this.reference.$el.getBoundingClientRect();
+            const requiredSpace = this.height + 16; // 16 for arrow, assuming same height on mobile for simplicity
+            if (triggerBoundingRect.top - referenceBoundingRect.top >= requiredSpace) {
                 this.tooltipPosition = 'top';
                 this.top = -this.height;
             } else {
@@ -142,8 +145,8 @@ export default class Tooltip extends Vue {
             const referenceLeftPad = parseInt(
                 window.getComputedStyle(this.reference.$el, null).getPropertyValue('padding-left'), 10);
             this.left =
-                this.reference.$el.getBoundingClientRect().left
-                - this.$el.getBoundingClientRect().left
+                referenceBoundingRect.left
+                - triggerBoundingRect.left
                 + referenceLeftPad;
         } else {
             this.tooltipPosition = 'top';

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -18,12 +18,13 @@
         </a>
         <transition :duration="isTakingInitialMeasurement ? 0 : undefined">
             <div ref="tooltipBox"
-                v-if="tooltipActive || isTakingInitialMeasurement"
+                v-if="tooltipActive"
                 class="tooltip-box"
                 :style="styles"
                 :class="{
                     top: tooltipPosition === 'top',
                     bottom: tooltipPosition === 'bottom',
+                    hidden: isTakingInitialMeasurement,
                 }">
                 <slot></slot>
             </div>
@@ -68,7 +69,7 @@ export default class Tooltip extends Vue {
     }
 
     private get tooltipActive() {
-        return this.tooltipToggled || this.mousedOver;
+        return this.tooltipToggled || this.mousedOver || this.isTakingInitialMeasurement;
     }
 
     private created() {
@@ -84,7 +85,7 @@ export default class Tooltip extends Vue {
     @Watch('tooltipActive', { immediate: true })
     public async update() {
         // updates dimensions and repositions tooltip
-        if (!this.tooltipActive && !this.isTakingInitialMeasurement) return; // no need to update as tooltip not visible
+        if (!this.tooltipActive) return; // no need to update as tooltip not visible
         if (!this.$el) {
             // wait until we're mounted
             await new Promise((resolve) => this.$once('hook:mounted', resolve));
@@ -113,7 +114,7 @@ export default class Tooltip extends Vue {
 
         // make sure that tooltipBox is rendered and apply new width then update measurements
         await Vue.nextTick();
-        if (!this.tooltipActive && !this.isTakingInitialMeasurement) return; // tooltip not visible anymore?
+        if (!this.tooltipActive) return; // tooltip not visible anymore?
         this.height = this.$refs.tooltipBox.offsetHeight;
         this.width = this.$refs.tooltipBox.offsetWidth;
         this.triggerHeight = this.$refs.tooltipTrigger.offsetHeight;
@@ -243,9 +244,8 @@ export default class Tooltip extends Vue {
         background: var(--nimiq-blue-bg);
         padding: 1.5rem;
         border-radius: .5rem;
-        transition: opacity .3s ease, visibility .3s, transform .2s ease, top .2s ease;
+        transition: opacity .3s ease, transform .2s ease, top .2s ease;
         box-shadow: 0 1.125rem 2.275rem rgba(0, 0, 0, 0.11);
-        visibility: hidden; /* for hiding on initial measurement */
     }
 
     .tooltip-box.v-enter,
@@ -259,9 +259,5 @@ export default class Tooltip extends Vue {
 
     .tooltip-box.top {
         transform: translateY(-2rem);
-    }
-
-    .tooltip.active .tooltip-box {
-        visibility: visible;
     }
 </style>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -292,9 +292,10 @@ export default Tooltip;
         content: '';
         display: block;
         position: absolute;
-        left: calc(50% - 1rem);
-        border-width: 1rem;
-        border-style: solid;
+        width: 2.25rem;
+        height: 2rem;
+        left: calc(50% - 1.125rem);
+        background-image: url('data:image/svg+xml,<svg viewBox="0 0 18 16" xmlns="http://www.w3.org/2000/svg"><path d="M9 7.12c-.47 0-.93.2-1.23.64L3.2 14.29A4 4 0 010 16h18a4 4 0 01-3.2-1.7l-4.57-6.54c-.3-.43-.76-.64-1.23-.64z" fill="%23151833"/></svg>');
         transition: opacity .3s ease, .3s visibility;
         transition-delay: 16ms; /* delay one animation frame for better sync with tooltipBox */
         visibility: hidden;
@@ -302,19 +303,16 @@ export default Tooltip;
     }
 
     .tooltip.transition-position > a::after {
-        transition: bottom .2s ease, top .2s ease, opacity .3s ease, .3s visibility;
+        transition: top .2s ease, transform .2s ease, opacity .3s ease, .3s visibility;
     }
 
     .tooltip.top > a::after {
-        border-color: var(--nimiq-blue-darkened) transparent transparent transparent;
         top: -2rem;
-        bottom: 0;
+        transform: scaleY(-1);
     }
 
     .tooltip.bottom > a::after {
-        border-color: transparent transparent var(--nimiq-blue-darkened) transparent;
-        top: 0;
-        bottom: -2rem;
+        top: 100%;
     }
 
     .tooltip.shown > a::after {

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -83,13 +83,18 @@ class Tooltip extends Vue {
         this.updatePosition = this.updatePosition.bind(this);
     }
 
+    private mounted() {
+        // Manually trigger an update instead of using immediate watchers to avoid unnecessary initial double updates
+        this.setReference(this.reference);
+    }
+
     private destroyed() {
         if (this.reference && this.reference.$el) {
             this.reference.$el.removeEventListener('scroll', this.updatePosition);
         }
     }
 
-    @Watch('tooltipActive', { immediate: true })
+    @Watch('tooltipActive')
     public async update() {
         // updates dimensions and repositions tooltip
         if (!this.tooltipActive) return; // no need to update as tooltip not visible
@@ -127,7 +132,7 @@ class Tooltip extends Vue {
         setTimeout(() => this.$el.style.overflow = 'unset', this.tooltipActive ? 0 : 300);
     }
 
-    @Watch('preferredPosition') // no need to be immediate watcher, as initially called by update
+    @Watch('preferredPosition')
     private updatePosition() {
         if (this.reference) {
             if (!this.reference.$el) {
@@ -167,8 +172,8 @@ class Tooltip extends Vue {
         }
     }
 
-    @Watch('reference', { immediate: true })
-    private async setReference(newReference: Vue | {$el: HTMLElement}, oldReference: Vue | {$el: HTMLElement}) {
+    @Watch('reference')
+    private async setReference(newReference: Vue | {$el: HTMLElement}, oldReference?: Vue | {$el: HTMLElement}) {
         if (oldReference && oldReference.$el) {
             oldReference.$el.removeEventListener('scroll', this.updatePosition);
         }

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -1,7 +1,6 @@
 <template>
     <span class="tooltip"
         :class="[tooltipPosition, {
-            disabled,
             shown: isShown,
             'transition-position': transitionPosition,
             'inverse-theme': theme === constructor.Themes.INVERSE,
@@ -13,7 +12,8 @@
             ref="tooltipTrigger"
             @focus.stop="show"
             @blur.stop="hide"
-            :tabindex="disabled ? -1 : false">
+            :tabindex="disabled ? -1 : false"
+            class="trigger">
             <slot name="trigger">
                 <AlertTriangleIcon class="nq-orange" />
             </slot>
@@ -282,27 +282,24 @@ export default Tooltip;
 
 <style scoped>
     .tooltip {
-        display: block;
+        display: inline-block;
         position: relative;
         line-height: 1;
     }
 
-    .tooltip > a {
+    .trigger {
         position: relative;
         display: block;
         text-decoration: none;
-    }
-
-    .tooltip.disabled > a {
         outline: none;
         cursor: default;
     }
 
-    .tooltip > a >>> svg {
+    .trigger >>> svg {
         display: block;
     }
 
-    .tooltip > a::after {
+    .trigger::after {
         opacity: 0;
         content: '';
         display: block;
@@ -316,27 +313,27 @@ export default Tooltip;
         transition-delay: 16ms; /* delay one animation frame for better sync with tooltipBox */
         visibility: hidden;
         pointer-events: visible;
-        z-index: 1;
+        z-index: 2; /* move above tooltip-box's box-shadow */
     }
 
-    .tooltip.inverse-theme > a::after {
+    .inverse-theme .trigger::after {
         background: white;
     }
 
-    .tooltip.transition-position > a::after {
+    .transition-position .trigger::after {
         transition: top .2s ease, transform .2s ease, opacity .3s ease, .3s visibility;
     }
 
-    .tooltip.top > a::after {
+    .top .trigger::after {
         top: -2rem;
         transform: scaleY(-1);
     }
 
-    .tooltip.bottom > a::after {
+    .bottom .trigger::after {
         top: 100%;
     }
 
-    .tooltip.shown > a::after {
+    .shown .trigger::after {
         opacity: 1;
         visibility: visible;
     }
@@ -347,16 +344,20 @@ export default Tooltip;
         background: var(--nimiq-blue-bg);
         padding: 1.5rem;
         border-radius: .5rem;
+        font-size: 1.75rem;
+        line-height: 1.5;
+        font-weight: 600;
         transition: opacity .3s ease;
         box-shadow: 0 1.125rem 2.275rem rgba(0, 0, 0, 0.11);
+        z-index: 1;
     }
 
-    .tooltip.inverse-theme .tooltip-box {
+    .inverse-theme .tooltip-box {
         color: var(--nimiq-blue);
         background: white;
     }
 
-    .tooltip.transition-position .tooltip-box {
+    .transition-position .tooltip-box {
         transition: opacity .3s ease, transform .2s ease, top .2s ease;
     }
 
@@ -365,11 +366,11 @@ export default Tooltip;
         opacity: 0;
     }
 
-    .tooltip.top .tooltip-box {
+    .top .tooltip-box {
         transform: translateY(-2rem);
     }
 
-    .tooltip.bottom .tooltip-box {
+    .bottom .tooltip-box {
         transform: translateY(2rem);
     }
 </style>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -4,6 +4,7 @@
             disabled,
             shown: isShown,
             'transition-position': transitionPosition,
+            'inverse-theme': theme === constructor.Themes.INVERSE,
         }]"
         @mouseenter="mouseOver(true)"
         @mouseleave="mouseOver(false)"
@@ -36,15 +37,24 @@ import { AlertTriangleIcon } from './Icons';
 class Tooltip extends Vue {
     @Prop(Object) public reference?: Vue | {$el: HTMLElement};
     @Prop(Boolean) public disabled?: boolean;
+
     @Prop({
         type: String,
         default: 'bottom' as Tooltip.Position.BOTTOM,
         validator: (value: any) => Object.values(Tooltip.Position).includes(value),
     }) public preferredPosition!: Tooltip.Position;
+
     @Prop({
         type: Boolean,
         default: false,
     }) public autoWidth!: boolean; // only relevant when using a reference
+
+    @Prop({
+        type: String,
+        default: 'normal' as Tooltip.Themes.NORMAL,
+        validator: (value: any) => Object.values(Tooltip.Themes).includes(value),
+    })
+    public theme!: Tooltip.Themes;
 
     // Typing of $refs and $el, in order to not having to cast it everywhere.
     public $refs!: {
@@ -260,6 +270,11 @@ namespace Tooltip {
         TOP = 'top',
         BOTTOM = 'bottom',
     }
+
+    export enum Themes {
+        NORMAL = 'normal',
+        INVERSE = 'inverse',
+    }
 }
 
 export default Tooltip;
@@ -295,11 +310,17 @@ export default Tooltip;
         width: 2.25rem;
         height: 2rem;
         left: calc(50% - 1.125rem);
-        background-image: url('data:image/svg+xml,<svg viewBox="0 0 18 16" xmlns="http://www.w3.org/2000/svg"><path d="M9 7.12c-.47 0-.93.2-1.23.64L3.2 14.29A4 4 0 010 16h18a4 4 0 01-3.2-1.7l-4.57-6.54c-.3-.43-.76-.64-1.23-.64z" fill="%23151833"/></svg>');
+        background: var(--nimiq-blue-bg-darkened);
+        mask-image: url('data:image/svg+xml,<svg viewBox="0 0 18 16" xmlns="http://www.w3.org/2000/svg"><path d="M9 7.12c-.47 0-.93.2-1.23.64L3.2 14.29A4 4 0 010 16h18a4 4 0 01-3.2-1.7l-4.57-6.54c-.3-.43-.76-.64-1.23-.64z" fill="white"/></svg>');
         transition: opacity .3s ease, .3s visibility;
         transition-delay: 16ms; /* delay one animation frame for better sync with tooltipBox */
         visibility: hidden;
         pointer-events: visible;
+        z-index: 1;
+    }
+
+    .tooltip.inverse-theme > a::after {
+        background: white;
     }
 
     .tooltip.transition-position > a::after {
@@ -328,6 +349,11 @@ export default Tooltip;
         border-radius: .5rem;
         transition: opacity .3s ease;
         box-shadow: 0 1.125rem 2.275rem rgba(0, 0, 0, 0.11);
+    }
+
+    .tooltip.inverse-theme .tooltip-box {
+        color: var(--nimiq-blue);
+        background: white;
     }
 
     .tooltip.transition-position .tooltip-box {

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -12,13 +12,13 @@
             ref="tooltipTrigger"
             @focus.stop="show"
             @blur.stop="hide"
-            :tabindex="disabled ? -1 : false"
+            :tabindex="disabled ? -1 : 0"
             class="trigger">
             <slot name="trigger">
                 <AlertTriangleIcon class="nq-orange" />
             </slot>
         </a>
-        <transition>
+        <transition name="transition-fade">
             <div ref="tooltipBox"
                 v-if="isShown"
                 class="tooltip-box"
@@ -94,6 +94,12 @@ class Tooltip extends Vue {
     }
 
     private mounted() {
+        if ('icon' in this.$slots) {
+            throw new Error('Deprecated Tooltip usage: slot `icon` has been renamed to `trigger`.');
+        }
+        if ('reference' in this) {
+            throw new Error('Deprecated Tooltip usage: prop `reference` has been renamed to `container`.');
+        }
         // Manually trigger an update instead of using immediate watchers to avoid unnecessary initial double updates
         this.setContainer(this.container);
     }
@@ -240,7 +246,7 @@ class Tooltip extends Vue {
                 await new Promise((resolve) => (newContainer as Vue).$once('hook:mounted', resolve));
                 if (newContainer !== this.container) return; // container changed
             }
-            // In case the container container is scrollable add a listener
+            // In case the container is scrollable add a listener
             await new Promise((resolve) => requestAnimationFrame(()  => {
                 if (newContainer.$el.scrollHeight !== (newContainer.$el as HTMLElement).offsetHeight) {
                     this.container.$el.addEventListener('scroll', this.updatePosition);
@@ -313,7 +319,7 @@ export default Tooltip;
         transition-delay: 16ms; /* delay one animation frame for better sync with tooltipBox */
         visibility: hidden;
         pointer-events: visible;
-        z-index: 2; /* move above tooltip-box's box-shadow */
+        z-index: 1000; /* move above tooltip-box's box-shadow */
     }
 
     .inverse-theme .trigger::after {
@@ -349,7 +355,7 @@ export default Tooltip;
         font-weight: 600;
         transition: opacity .3s ease;
         box-shadow: 0 1.125rem 2.275rem rgba(0, 0, 0, 0.11);
-        z-index: 1;
+        z-index: 999;
     }
 
     .inverse-theme .tooltip-box {
@@ -361,8 +367,8 @@ export default Tooltip;
         transition: opacity .3s ease, transform .2s ease, top .2s ease;
     }
 
-    .tooltip-box.v-enter,
-    .tooltip-box.v-leave-to {
+    .tooltip-box.transition-fade-enter,
+    .tooltip-box.transition-fade-leave-to {
         opacity: 0;
     }
 

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -8,9 +8,11 @@
             ref="tooltipTrigger"
             @focus.stop="toggleTooltip"
             @blur.stop="tooltipToggled ? toggleTooltip() : ''"
+            :tabindex="disabled ? -1 : false"
             :class="{
                 top: tooltipPosition === 'top',
                 bottom: tooltipPosition === 'bottom',
+                disabled,
             }">
             <slot name="trigger">
                 <AlertTriangleIcon class="nq-orange" />
@@ -39,6 +41,7 @@ import { AlertTriangleIcon } from './Icons';
 @Component({ components: { AlertTriangleIcon }})
 export default class Tooltip extends Vue {
     @Prop(Object) public reference?: Vue | {$el: HTMLElement};
+    @Prop(Boolean) public disabled?: boolean;
 
     // Typing of $refs and $el, in order to not having to cast it everywhere.
     public $refs!: {
@@ -69,7 +72,7 @@ export default class Tooltip extends Vue {
     }
 
     private get tooltipActive() {
-        return this.tooltipToggled || this.mousedOver || this.isTakingInitialMeasurement;
+        return (this.tooltipToggled || this.mousedOver || this.isTakingInitialMeasurement) && !this.disabled;
     }
 
     private created() {
@@ -201,6 +204,11 @@ export default class Tooltip extends Vue {
         position: relative;
         display: block;
         text-decoration: none;
+    }
+
+    .tooltip > a.disabled {
+        outline: none;
+        cursor: default;
     }
 
     .tooltip > a >>> svg {

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -5,14 +5,14 @@
         @mouseleave="mouseOver(false)"
     >
         <a href="javascript:void(0);"
-            ref="tooltipIcon"
+            ref="tooltipTrigger"
             @focus.stop="toggleTooltip"
             @blur.stop="tooltipToggled ? toggleTooltip() : ''"
             :class="{
                 top: tooltipPosition === 'top',
                 bottom: tooltipPosition === 'bottom',
             }">
-            <slot name="icon">
+            <slot name="trigger">
                 <AlertTriangleIcon class="nq-orange" />
             </slot>
         </a>
@@ -41,7 +41,7 @@ export default class Tooltip extends Vue {
     // Typing of $refs and $el, in order to not having to cast it everywhere.
     public $refs!: {
         tooltipBox: HTMLDivElement,
-        tooltipIcon: HTMLAnchorElement,
+        tooltipTrigger: HTMLAnchorElement,
     };
     public $el: HTMLElement;
 
@@ -50,7 +50,7 @@ export default class Tooltip extends Vue {
     private mousedOver: boolean = false;
     private mouseOverTimeout: number;
 
-    private iconHeight: number = 0;
+    private triggerHeight: number = 0;
     private height: number = 0;
     private width: number = 0;
     private left: number = 0;
@@ -96,7 +96,7 @@ export default class Tooltip extends Vue {
                 this.top = -this.height;
             } else {
                 this.tooltipPosition = 'bottom';
-                this.top = this.iconHeight;
+                this.top = this.triggerHeight;
             }
         } else {
             this.tooltipPosition = 'top';
@@ -121,7 +121,7 @@ export default class Tooltip extends Vue {
 
             this.width = this.reference.$el.offsetWidth - referenceLeftPad - referenceRightPad;
 
-            this.iconHeight = this.$el.offsetHeight;
+            this.triggerHeight = this.$el.offsetHeight;
             // reset height
             this.height = 0;
             this.top = 0;
@@ -149,7 +149,7 @@ export default class Tooltip extends Vue {
         this.tooltipToggled = !this.tooltipToggled;
 
         if (!this.tooltipToggled) {
-            this.$refs.tooltipIcon.blur();
+            this.$refs.tooltipTrigger.blur();
         }
     }
 
@@ -182,6 +182,7 @@ export default class Tooltip extends Vue {
     .tooltip > a {
         position: relative;
         display: block;
+        text-decoration: none;
     }
 
     .tooltip > a >>> svg {

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -42,7 +42,7 @@ class Tooltip extends Vue {
 
     @Prop({
         type: String,
-        default: 'bottom right',
+        default: 'top right',
         validator: (value: unknown) => {
             if (typeof value !== 'string') return false;
             const [vertical, horizontal] = value.split(' ');

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -341,7 +341,7 @@ export default Tooltip;
         height: 2rem;
         left: calc(50% - 1.125rem);
         background: var(--nimiq-blue-bg-darkened);
-        mask-image: url('data:image/svg+xml,<svg viewBox="0 0 18 16" xmlns="http://www.w3.org/2000/svg"><path d="M9 7.12c-.47 0-.93.2-1.23.64L3.2 14.29A4 4 0 010 16h18a4 4 0 01-3.2-1.7l-4.57-6.54c-.3-.43-.76-.64-1.23-.64z" fill="white"/></svg>');
+        mask-image: url('data:image/svg+xml,<svg viewBox="0 0 18 16" xmlns="http://www.w3.org/2000/svg"><path d="M9 7.12c-.47 0-.93.2-1.23.64L3.2 14.29A4 4 0 0 1 0 16h18a4 4 0 0 1-3.2-1.7l-4.57-6.54c-.3-.43-.76-.64-1.23-.64z" fill="white"/></svg>');
         transition: opacity .3s ease, .3s visibility;
         transition-delay: 16ms; /* delay one animation frame for better sync with tooltipBox */
         visibility: hidden;

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -1,6 +1,10 @@
 <template>
     <span class="tooltip"
-        :class="{ active: tooltipActive }"
+        :class="[tooltipPosition, {
+            disabled,
+            active: tooltipActive,
+            'transition-position': transitionPosition,
+        }]"
         @mouseenter="mouseOver(true)"
         @mouseleave="mouseOver(false)"
     >
@@ -8,13 +12,7 @@
             ref="tooltipTrigger"
             @focus.stop="toggleTooltip"
             @blur.stop="tooltipToggled ? toggleTooltip() : ''"
-            :tabindex="disabled ? -1 : false"
-            :class="{
-                top: tooltipPosition === constructor.Position.TOP,
-                bottom: tooltipPosition === constructor.Position.BOTTOM,
-                'transition-position': transitionPosition,
-                disabled,
-            }">
+            :tabindex="disabled ? -1 : false">
             <slot name="trigger">
                 <AlertTriangleIcon class="nq-orange" />
             </slot>
@@ -23,12 +21,7 @@
             <div ref="tooltipBox"
                 v-if="tooltipActive"
                 class="tooltip-box"
-                :style="styles"
-                :class="{
-                    top: tooltipPosition === constructor.Position.TOP,
-                    bottom: tooltipPosition === constructor.Position.BOTTOM,
-                    'transition-position': transitionPosition,
-                }">
+                :style="styles">
                 <slot></slot>
             </div>
         </transition>
@@ -271,7 +264,7 @@ export default Tooltip;
         text-decoration: none;
     }
 
-    .tooltip > a.disabled {
+    .tooltip.disabled > a {
         outline: none;
         cursor: default;
     }
@@ -294,17 +287,17 @@ export default Tooltip;
         pointer-events: visible;
     }
 
-    .tooltip > a.transition-position::after {
+    .tooltip.transition-position > a::after {
         transition: bottom .2s ease, top .2s ease, opacity .3s ease, .3s visibility;
     }
 
-    .tooltip > a.top::after {
+    .tooltip.top > a::after {
         border-color: var(--nimiq-blue-darkened) transparent transparent transparent;
         top: -2rem;
         bottom: 0;
     }
 
-    .tooltip > a.bottom::after {
+    .tooltip.bottom > a::after {
         border-color: transparent transparent var(--nimiq-blue-darkened) transparent;
         top: 0;
         bottom: -2rem;
@@ -325,7 +318,7 @@ export default Tooltip;
         box-shadow: 0 1.125rem 2.275rem rgba(0, 0, 0, 0.11);
     }
 
-    .tooltip-box.transition-position {
+    .tooltip.transition-position .tooltip-box {
         transition: opacity .3s ease, transform .2s ease, top .2s ease;
     }
 
@@ -334,11 +327,11 @@ export default Tooltip;
         opacity: 0;
     }
 
-    .tooltip-box.bottom {
-        transform: translateY(2rem);
+    .tooltip.top .tooltip-box {
+        transform: translateY(-2rem);
     }
 
-    .tooltip-box.top {
-        transform: translateY(-2rem);
+    .tooltip.bottom .tooltip-box {
+        transform: translateY(2rem);
     }
 </style>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -46,9 +46,10 @@ class Tooltip extends Vue {
         validator: (value: unknown) => {
             if (typeof value !== 'string') return false;
             const [vertical, horizontal] = value.split(' ');
-            return Object.values(Tooltip.VerticalPosition).includes(vertical)
-                && (!horizontal || Object.values(Tooltip.HorizontalPosition).includes(horizontal));
-        }
+            return Object.values(Tooltip.VerticalPosition).includes(vertical as Tooltip.VerticalPosition)
+                && (!horizontal || Object.values(Tooltip.HorizontalPosition)
+                    .includes(horizontal as Tooltip.HorizontalPosition));
+        },
     }) public preferredPosition!: string;
 
     @Prop({
@@ -204,6 +205,7 @@ class Tooltip extends Vue {
         if (!this.isShown) return;
         // Note that in his method we do not need to use requestAnimationFrame to avoid reflows, as the method is
         // already called as a scroll event listener or manually in update after a reflow.
+        // tslint:disable-next-line:prefer-const
         let [preferredVerticalPosition, preferredHorizontalPosition] = this.preferredPosition.split(' ');
         preferredHorizontalPosition = preferredHorizontalPosition || Tooltip.HorizontalPosition.RIGHT;
         this.left = preferredHorizontalPosition === Tooltip.HorizontalPosition.RIGHT

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -1,7 +1,6 @@
 import {storiesOf} from '@storybook/vue';
 import {action} from '@storybook/addon-actions';
 import {boolean, number, text, object, select, withKnobs} from '@storybook/addon-knobs';
-import bigInt from 'big-integer';
 
 import Account from '../components/Account.vue';
 import AccountDetails from '../components/AccountDetails.vue';
@@ -234,6 +233,7 @@ storiesOf('Basic', module)
     .add('Tooltip', () => {
         const useReference = boolean('Use referenceFrame', true);
         const preferredPosition = select('preferredPosition', Object.values(Tooltip.Position), Tooltip.Position.TOP);
+        const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
         const fontSize = number('Font size (rem)', 3);
         return {
@@ -243,6 +243,7 @@ storiesOf('Basic', module)
                     message: '',
                     useReference,
                     preferredPosition,
+                    autoWidth,
                     disabled,
                     fontSize,
                 };
@@ -271,9 +272,10 @@ storiesOf('Basic', module)
                                     <LabelInput v-model="message" style="display: inline;"/>
                                     <Tooltip :reference="useReference ? target : undefined"
                                         :preferredPosition="preferredPosition"
+                                        :autoWidth="autoWidth"
                                         :disabled="disabled"
                                         :style="style">
-                                        <div style="font-size: 2rem;">
+                                        <div style="font-size: 2rem; min-width: 25rem">
                                             This is the Tooltip I was talking about.
                                             <Account address="NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM" />
                                         </div>

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -232,7 +232,7 @@ storiesOf('Basic', module)
     })
     .add('Tooltip', () => {
         const useContainer = boolean('Use container', true);
-        const preferredPosition = text('preferredPosition', 'bottom right');
+        const preferredPosition = text('preferredPosition', 'top right');
         const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
         const theme = select('theme', Object.values(Tooltip.Themes), Tooltip.Themes.NORMAL);

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -231,7 +231,7 @@ storiesOf('Basic', module)
         }
     })
     .add('Tooltip', () => {
-        const useReference = boolean('Use referenceFrame', true);
+        const useContainer = boolean('Use container', true);
         const preferredPosition = select('preferredPosition', Object.values(Tooltip.Position), Tooltip.Position.TOP);
         const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
@@ -240,7 +240,7 @@ storiesOf('Basic', module)
         return {
             data() {
                 return {
-                    useReference,
+                    useContainer,
                     preferredPosition,
                     autoWidth,
                     disabled,
@@ -251,9 +251,9 @@ storiesOf('Basic', module)
                 };
             },
             computed: {
-                target() {
+                container() {
                     if(this.refsLoaded)
-                        return this.$refs.target;
+                        return this.$refs.container;
                     else return null;
                 },
             },
@@ -263,7 +263,7 @@ storiesOf('Basic', module)
             components: { SmallPage, PageHeader, PageBody, Tooltip, Account },
             template: windowTemplate`<SmallPage :class="{ 'nq-blue-bg': theme === 'inverse' }">
                             <PageHeader>Test</PageHeader>
-                            <PageBody ref="target" style="overflow-y: scroll; position:relative;">
+                            <PageBody ref="container" style="overflow-y: scroll; position:relative;">
                                 <div style="height:320px"></div>
                                 <div style="max-width: 100%; display: flex; align-items: center;">
                                     <button class="nq-button-s" :class="[theme]" @click="$refs.tooltip.show()">
@@ -275,7 +275,7 @@ storiesOf('Basic', module)
                                     </button>
                                     &nbsp;or hover me:&nbsp;
                                     <Tooltip ref="tooltip"
-                                        :reference="useReference ? target : undefined"
+                                        :container="useContainer ? container : undefined"
                                         :preferredPosition="preferredPosition"
                                         :autoWidth="autoWidth"
                                         :disabled="disabled"

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -232,7 +232,7 @@ storiesOf('Basic', module)
     })
     .add('Tooltip', () => {
         const useContainer = boolean('Use container', true);
-        const preferredPosition = select('preferredPosition', Object.values(Tooltip.Position), Tooltip.Position.TOP);
+        const preferredPosition = text('preferredPosition', 'bottom right');
         const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
         const theme = select('theme', Object.values(Tooltip.Themes), Tooltip.Themes.NORMAL);

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -234,6 +234,7 @@ storiesOf('Basic', module)
     .add('Tooltip', () => {
         const fontSize = number('Font size (rem)', 3);
         const useReference = boolean('Use referenceFrame', true);
+        const disabled = boolean('disabled', false);
         return {
             data() {
                 return {
@@ -241,6 +242,7 @@ storiesOf('Basic', module)
                     message: '',
                     fontSize,
                     useReference,
+                    disabled,
                 };
             },
             computed: {
@@ -265,7 +267,9 @@ storiesOf('Basic', module)
                                 <div style="height:300px"></div>
                                 <div style="max-width: 100%; display: flex; align-items: center;">
                                     <LabelInput v-model="message" style="display: inline;"/>
-                                    <Tooltip :reference="useReference ? target : undefined" :style="style">
+                                    <Tooltip :reference="useReference ? target : undefined"
+                                        :style="style"
+                                        :disabled="disabled">
                                         <div style="font-size: 2rem;">
                                             This is the Tooltip I was talking about.
                                             <Account address="NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM" />

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -235,6 +235,7 @@ storiesOf('Basic', module)
         const preferredPosition = select('preferredPosition', Object.values(Tooltip.Position), Tooltip.Position.TOP);
         const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
+        const theme = select('theme', Object.values(Tooltip.Themes), Tooltip.Themes.NORMAL);
         const fontSize = number('Font size (rem)', 3);
         return {
             data() {
@@ -243,6 +244,7 @@ storiesOf('Basic', module)
                     preferredPosition,
                     autoWidth,
                     disabled,
+                    theme,
                     fontSize,
                     refsLoaded: false,
                     shown: false,
@@ -259,20 +261,25 @@ storiesOf('Basic', module)
                 this.refsLoaded = true;
             },
             components: { SmallPage, PageHeader, PageBody, Tooltip, Account },
-            template: windowTemplate`<SmallPage>
+            template: windowTemplate`<SmallPage :class="{ 'nq-blue-bg': theme === 'inverse' }">
                             <PageHeader>Test</PageHeader>
-                            <PageBody style="overflow-y: scroll; position:relative;" ref="target">
+                            <PageBody ref="target" style="overflow-y: scroll; position:relative;">
                                 <div style="height:320px"></div>
                                 <div style="max-width: 100%; display: flex; align-items: center;">
-                                    <button class="nq-button-s" @click="$refs.tooltip.show()">Show</button>
+                                    <button class="nq-button-s" :class="[theme]" @click="$refs.tooltip.show()">
+                                        Show
+                                    </button>
                                     &nbsp;or&nbsp;
-                                    <button class="nq-button-s" @click="$refs.tooltip.hide()">hide</button>
+                                    <button class="nq-button-s" :class="[theme]" @click="$refs.tooltip.hide()">
+                                        hide
+                                    </button>
                                     &nbsp;or hover me:&nbsp;
                                     <Tooltip ref="tooltip"
                                         :reference="useReference ? target : undefined"
                                         :preferredPosition="preferredPosition"
                                         :autoWidth="autoWidth"
                                         :disabled="disabled"
+                                        :theme="theme"
                                         :style="{ fontSize: fontSize + 'rem' }"
                                         @show="shown = true"
                                         @hide="shown = false">

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -232,17 +232,19 @@ storiesOf('Basic', module)
         }
     })
     .add('Tooltip', () => {
-        const fontSize = number('Font size (rem)', 3);
         const useReference = boolean('Use referenceFrame', true);
+        const preferredPosition = select('preferredPosition', Object.values(Tooltip.Position), Tooltip.Position.TOP);
         const disabled = boolean('disabled', false);
+        const fontSize = number('Font size (rem)', 3);
         return {
             data() {
                 return {
                     refsLoaded: false,
                     message: '',
-                    fontSize,
                     useReference,
+                    preferredPosition,
                     disabled,
+                    fontSize,
                 };
             },
             computed: {
@@ -264,12 +266,13 @@ storiesOf('Basic', module)
             template: windowTemplate`<SmallPage>
                             <PageHeader>Test</PageHeader>
                             <PageBody style="overflow-y: scroll; position:relative;" ref="target">
-                                <div style="height:300px"></div>
+                                <div style="height:320px"></div>
                                 <div style="max-width: 100%; display: flex; align-items: center;">
                                     <LabelInput v-model="message" style="display: inline;"/>
                                     <Tooltip :reference="useReference ? target : undefined"
-                                        :style="style"
-                                        :disabled="disabled">
+                                        :preferredPosition="preferredPosition"
+                                        :disabled="disabled"
+                                        :style="style">
                                         <div style="font-size: 2rem;">
                                             This is the Tooltip I was talking about.
                                             <Account address="NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM" />

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -239,13 +239,13 @@ storiesOf('Basic', module)
         return {
             data() {
                 return {
-                    refsLoaded: false,
-                    message: '',
                     useReference,
                     preferredPosition,
                     autoWidth,
                     disabled,
                     fontSize,
+                    refsLoaded: false,
+                    shown: false,
                 };
             },
             computed: {
@@ -254,32 +254,36 @@ storiesOf('Basic', module)
                         return this.$refs.target;
                     else return null;
                 },
-                style() {
-                    return {
-                        fontSize: this.fontSize + 'rem',
-                    };
-                }
             },
             mounted() {
                 this.refsLoaded = true;
             },
-            components: { SmallPage, PageHeader, PageBody, Tooltip, Icons, Account, LabelInput },
+            components: { SmallPage, PageHeader, PageBody, Tooltip, Account },
             template: windowTemplate`<SmallPage>
                             <PageHeader>Test</PageHeader>
                             <PageBody style="overflow-y: scroll; position:relative;" ref="target">
                                 <div style="height:320px"></div>
                                 <div style="max-width: 100%; display: flex; align-items: center;">
-                                    <LabelInput v-model="message" style="display: inline;"/>
-                                    <Tooltip :reference="useReference ? target : undefined"
+                                    <button class="nq-button-s" @click="$refs.tooltip.show()">Show</button>
+                                    &nbsp;or&nbsp;
+                                    <button class="nq-button-s" @click="$refs.tooltip.hide()">hide</button>
+                                    &nbsp;or hover me:&nbsp;
+                                    <Tooltip ref="tooltip"
+                                        :reference="useReference ? target : undefined"
                                         :preferredPosition="preferredPosition"
                                         :autoWidth="autoWidth"
                                         :disabled="disabled"
-                                        :style="style">
+                                        :style="{ fontSize: fontSize + 'rem' }"
+                                        @show="shown = true"
+                                        @hide="shown = false">
                                         <div style="font-size: 2rem; min-width: 25rem">
                                             This is the Tooltip I was talking about.
                                             <Account address="NQ55 VDTM 6PVTN672 SECN JKVD 9KE4 SD91 PCCM" />
                                         </div>
                                     </Tooltip>
+                                </div>
+                                <div>
+                                    Shown: {{shown}}
                                 </div>
                                 <div style="height:3000px"></div>
                             </PageBody>


### PR DESCRIPTION
Variety of improvements to the tooltip component, see commit history.
Notably, this PR also makes the component suitable for more use cases. It can now handle tooltips of arbitrary size, allows for a preferred position, has an inverse theme, can be disabled and has a programmatic api.
Additionally, style fixes, code beautifications and performance improvements have been applied.
Also the component is now less restrictive in the reference / tooltip setup (supports references that are not the offsetParent of the tooltip and properly updates measurements on update also if the the reference resized).
Also this fixes a scroll bar issue which appeared after the vue / dependencies update and can currently be witnessed in the create cashlink flow.