### PR TITLE
Use tooltips in components

### DIFF
--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -32,7 +32,7 @@
                     preferredPosition: 'bottom left',
                     ...tooltipProps,
                     styles: {
-                        width: '23rem',
+                        width: '22.25rem',
                         cursor: 'default',
                         ...(tooltipProps ? tooltipProps.styles : undefined),
                     },
@@ -40,8 +40,8 @@
                 @click.native.stop
             >
                 {{ _isDisabledContract(account)
-                    ? 'Contracts are ineligible for this operation.'
-                    : 'This address can not be used in this operation.'
+                    ? 'Contracts cannot be used for this operation.'
+                    : 'This address cannot be used for this operation.'
                 }}
             </Tooltip>
         </component>

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -28,8 +28,10 @@
             <CaretRightSmallIcon v-if="!_isDisabled(account)" class="caret"/>
             <Tooltip v-if="_hasTooltip(account)"
                 :ref="`tooltip-${account.userFriendlyAddress}`"
-                preferredPosition="bottom left"
-                :container="$parent"
+                v-bind="{
+                    preferredPosition: 'bottom left',
+                    ...tooltipProps,
+                }"
                 @click.native.stop
             >
                 <div class="tooltip-content">
@@ -60,6 +62,7 @@ export default class AccountList extends Vue {
     @Prop(Number) private minBalance?: number;
     @Prop(Boolean) private disableContracts?: boolean;
     @Prop(Boolean) private disabled?: boolean;
+    @Prop(Object) private tooltipProps?: object;
 
     private highlightedDisabledAddress: string | null = null;
     private highlightedDisabledAddressTimeout: number = -1;

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -3,17 +3,15 @@
         <component :is="accountContainerTag" href="javascript:void(0)" class="account-entry"
             v-for="account in accounts"
             :class="{
-                'disabled': disabled
-                    || disableContracts && _isContract(account)
-                    || minBalance && account.balance < minBalance
-                    || disabledAddresses.includes(account.userFriendlyAddress),
-                'disabled-contract': disableContracts && _isContract(account),
-                'good-balance': minBalance && (account.balance || 0) >= minBalance,
-                'bad-balance': minBalance && (account.balance || 0) < minBalance,
-                'highlight-disabled-address': highlightedDisabledAddress === account.userFriendlyAddress,
-                'disabled-address-not-viable': disabledAddresses.includes(account.userFriendlyAddress),
+                'disabled': _isDisabled(account),
+                'has-tooltip': _hasTooltip(account),
+                'highlight-insufficient-balance': highlightedDisabledAddress === account.userFriendlyAddress
+                    && _hasInsufficientBalance(account)
+                    && !_isDisabledContract(account)
+                    && !_isDisabledAccount(account),
             }"
-            @click="accountSelected(account)" :key="account.userFriendlyAddress"
+            @click="accountSelected(account)"
+            :key="account.userFriendlyAddress"
         >
             <Account :ref="account.userFriendlyAddress"
                 :address="account.userFriendlyAddress"
@@ -25,7 +23,20 @@
                 @changed="accountChanged(account.userFriendlyAddress, $event)"
             />
 
-            <CaretRightSmallIcon/>
+            <CaretRightSmallIcon v-if="!_isDisabled(account)" class="caret"/>
+            <Tooltip v-if="_hasTooltip(account)"
+                :ref="`tooltip-${account.userFriendlyAddress}`"
+                preferredPosition="bottom left"
+                :container="$parent"
+                @click.native.stop
+            >
+                <div class="tooltip-content">
+                    {{ _isDisabledContract(account)
+                        ? 'Contracts are ineligible for this operation.'
+                        : 'This address can not be used in this operation.'
+                    }}
+                </div>
+            </Tooltip>
         </component>
     </div>
 </template>
@@ -34,9 +45,10 @@
 import {Component, Emit, Prop, Vue} from 'vue-property-decorator';
 import Account from './Account.vue';
 import { AccountInfo, ContractInfo } from './AccountSelector.vue';
+import Tooltip from './Tooltip.vue';
 import { CaretRightSmallIcon } from './Icons';
 
-@Component({components: {Account, CaretRightSmallIcon}})
+@Component({components: {Account, Tooltip, CaretRightSmallIcon}})
 export default class AccountList extends Vue {
     @Prop(Array) public accounts!: AccountInfo[];
     @Prop({type: Array, default: () => []}) public disabledAddresses!: string[];
@@ -48,7 +60,7 @@ export default class AccountList extends Vue {
     @Prop(Boolean) private disabled?: boolean;
 
     private highlightedDisabledAddress: string | null = null;
-    private highlightedDisabledAddressTimeout: number | null = null;
+    private highlightedDisabledAddressTimeout: number = -1;
 
     public focus(address: string) {
         if (this.editable && this.$refs.hasOwnProperty(address)) {
@@ -59,20 +71,23 @@ export default class AccountList extends Vue {
     private accountSelected(account: AccountInfo) {
         if (this.disabled) return;
 
-        const hasEnoughBalance = !this.minBalance || account.balance >= this.minBalance;
-        if (this.highlightedDisabledAddressTimeout) {
-            window.clearTimeout(this.highlightedDisabledAddressTimeout);
-            this.highlightedDisabledAddressTimeout = null;
+        window.clearTimeout(this.highlightedDisabledAddressTimeout);
+        if (account.userFriendlyAddress !== this.highlightedDisabledAddress) {
+            this._clearHighlightedDisabledAddress();
         }
-        const isDisabledContract = this.disableContracts && this._isContract(account);
-        const isDisabledAddress = this.disabledAddresses.includes(account.userFriendlyAddress);
+
+        const isDisabledContract = this._isDisabledContract(account);
+        const isDisabledAccount = this._isDisabledAccount(account);
         if (isDisabledContract
-            || (this.minBalance && account.balance < this.minBalance)
-            || isDisabledAddress) {
-            const waitTime = isDisabledContract || isDisabledAddress ? 1500 : 300;
+            || isDisabledAccount
+            || this._hasInsufficientBalance(account)) {
             this.highlightedDisabledAddress = account.userFriendlyAddress;
+            if (this.$refs[`tooltip-${this.highlightedDisabledAddress}`]) {
+                (this.$refs[`tooltip-${this.highlightedDisabledAddress}`] as Tooltip[])[0].show();
+            }
+            const waitTime = isDisabledContract || isDisabledAccount ? 2000 : 300;
             this.highlightedDisabledAddressTimeout =
-                window.setTimeout(() => this.highlightedDisabledAddress = null, waitTime);
+                window.setTimeout(() => this._clearHighlightedDisabledAddress(), waitTime);
         } else {
             this.$emit('account-selected', account.walletId || this.walletId, account.userFriendlyAddress);
         }
@@ -86,8 +101,36 @@ export default class AccountList extends Vue {
     // tslint:disable-next-line no-empty
     private accountChanged(address: string, label: string) {}
 
-    private _isContract(account: AccountInfo | ContractInfo) {
-        return !('path' in account) || !account.path;
+    private _isDisabled(account: AccountInfo | ContractInfo) {
+        return this.disabled
+            || this._isDisabledContract(account)
+            || this._isDisabledAccount(account)
+            || this._hasInsufficientBalance(account);
+    }
+
+    private _isDisabledContract(account: AccountInfo | ContractInfo) {
+        return this.disableContracts && !('path' in account && account.path);
+    }
+
+    private _isDisabledAccount(account: AccountInfo | ContractInfo) {
+        return this.disabledAddresses.includes(account.userFriendlyAddress);
+    }
+
+    private _hasInsufficientBalance(account: AccountInfo | ContractInfo) {
+        return this.minBalance && account.balance < this.minBalance;
+    }
+
+    private _hasTooltip(account: AccountInfo | ContractInfo) {
+        return !this.disabled && (this._isDisabledContract(account) || this._isDisabledAccount(account));
+    }
+
+    private _clearHighlightedDisabledAddress() {
+        if (!this.highlightedDisabledAddress) return;
+        if (this.$refs[`tooltip-${this.highlightedDisabledAddress}`]) {
+            // Hide tooltip if it's not hovered
+            (this.$refs[`tooltip-${this.highlightedDisabledAddress}`] as Tooltip[])[0].hide(/* force */ false);
+        }
+        this.highlightedDisabledAddress = null;
     }
 }
 </script>
@@ -124,10 +167,6 @@ export default class AccountList extends Vue {
         opacity: 1;
     }
 
-    .account-entry .account {
-        transition: opacity .3s var(--nimiq-ease);
-    }
-
     .account-entry >>> .identicon img {
         transform: scale(0.9);
         transition: transform .45s var(--nimiq-ease);
@@ -138,11 +177,15 @@ export default class AccountList extends Vue {
         transition: opacity .3s var(--nimiq-ease), color .3s var(--nimiq-ease), margin-right .45s var(--nimiq-ease);
     }
 
-    .account-entry .nq-icon {
+    .account-entry .caret,
+    .account-entry .tooltip {
         position: absolute;
         right: 2rem;
         top: 3.625rem;
         font-size: 2rem;
+    }
+
+    .account-entry .caret {
         transform: translateX(3rem);
         opacity: 0;
         transition: transform .45s var(--nimiq-ease), opacity .35s .1s var(--nimiq-ease);
@@ -157,8 +200,8 @@ export default class AccountList extends Vue {
         background-color: rgba(31, 35, 72, 0.06); /* Based on Nimiq Blue */
     }
 
-    a.account-entry:not(.disabled):hover >>> img,
-    a.account-entry:not(.disabled):focus >>> img {
+    a.account-entry:not(.disabled):hover >>> .identicon img,
+    a.account-entry:not(.disabled):focus >>> .identicon img {
         transform: scale(1);
     }
 
@@ -169,14 +212,19 @@ export default class AccountList extends Vue {
         opacity: 1;
     }
 
-    a.account-entry:not(.disabled).good-balance:hover >>> .balance,
-    a.account-entry:not(.disabled).good-balance:focus >>> .balance {
-        margin-right: 3rem;
+    a.account-entry:not(.disabled):hover >>> .balance,
+    a.account-entry:not(.disabled):focus >>> .balance,
+    a.account-entry.has-tooltip >>> .balance {
+        margin-right: 3rem; /* make space for caret or tooltip trigger */
+    }
+
+    a.account-entry:not(.disabled):hover >>> .balance,
+    a.account-entry:not(.disabled):focus >>> .balance {
         color: var(--nimiq-green);
     }
 
-    a.account-entry:not(.disabled).good-balance:hover .nq-icon,
-    a.account-entry:not(.disabled).good-balance:focus .nq-icon {
+    a.account-entry:not(.disabled):hover .caret,
+    a.account-entry:not(.disabled):focus .caret {
         transform: translateX(0);
         opacity: 0.23;
     }
@@ -191,42 +239,13 @@ export default class AccountList extends Vue {
         opacity: 0.2;
     }
 
-    a.account-entry.bad-balance:not(.disabled-contract):not(.disabled-address-not-viable).highlight-disabled-address >>> .balance {
+    a.account-entry.highlight-insufficient-balance >>> .balance {
         color: var(--nimiq-red);
         opacity: 1;
     }
 
-    a.account-entry.disabled-contract::after,
-    a.account-entry.disabled-address-not-viable::after {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-        color: var(--nimiq-red);
-        transition: opacity .3s var(--nimiq-ease);
-        opacity: 0;
-    }
-
-    a.account-entry.disabled-contract::after {
-        content: 'Contracts are incompatible with this operation.';
-    }
-
-    a.account-entry.disabled-address-not-viable::after {
-        content: 'This address cannot be used in this operation.';
-    }
-
-    a.account-entry.disabled-contract.highlight-disabled-address .account,
-    a.account-entry.disabled-address-not-viable.highlight-disabled-address .account {
-        opacity: .2;
-    }
-
-    a.account-entry.disabled-contract.highlight-disabled-address::after,
-    a.account-entry.disabled-address-not-viable.highlight-disabled-address::after {
-        opacity: 1;
+    a.account-entry >>> .tooltip-box {
+        width: 23rem;
+        cursor: default;
     }
 </style>

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -69,7 +69,7 @@ export default class AccountList extends Vue {
     }
 
     private accountSelected(account: AccountInfo) {
-        if (this.disabled) return;
+        if (this.disabled || this.editable) return;
 
         window.clearTimeout(this.highlightedDisabledAddressTimeout);
         if (account.userFriendlyAddress !== this.highlightedDisabledAddress) {
@@ -121,7 +121,8 @@ export default class AccountList extends Vue {
     }
 
     private _hasTooltip(account: AccountInfo | ContractInfo) {
-        return !this.disabled && (this._isDisabledContract(account) || this._isDisabledAccount(account));
+        return !this.disabled && !this.editable
+            && (this._isDisabledContract(account) || this._isDisabledAccount(account));
     }
 
     private _clearHighlightedDisabledAddress() {

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -33,7 +33,7 @@
                     ...tooltipProps,
                     styles: {
                         width: '22.25rem',
-                        cursor: 'default',
+                        pointerEvents: 'none',
                         ...(tooltipProps ? tooltipProps.styles : undefined),
                     },
                 }"

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -31,15 +31,18 @@
                 v-bind="{
                     preferredPosition: 'bottom left',
                     ...tooltipProps,
+                    styles: {
+                        width: '23rem',
+                        cursor: 'default',
+                        ...(tooltipProps ? tooltipProps.styles : undefined),
+                    },
                 }"
                 @click.native.stop
             >
-                <div class="tooltip-content">
-                    {{ _isDisabledContract(account)
-                        ? 'Contracts are ineligible for this operation.'
-                        : 'This address can not be used in this operation.'
-                    }}
-                </div>
+                {{ _isDisabledContract(account)
+                    ? 'Contracts are ineligible for this operation.'
+                    : 'This address can not be used in this operation.'
+                }}
             </Tooltip>
         </component>
     </div>
@@ -239,10 +242,5 @@ export default class AccountList extends Vue {
     .account-entry.highlight-insufficient-balance >>> .balance {
         color: var(--nimiq-red);
         opacity: 1;
-    }
-
-    .account-entry >>> .tooltip-box {
-        width: 23rem;
-        cursor: default;
     }
 </style>

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="account-list">
-        <component :is="accountContainerTag" href="javascript:void(0)" class="account-entry"
+        <component :is="!_isDisabled(account) && !editable ? 'a' : 'div'"
+            href="javascript:void(0)"
+            class="account-entry"
             v-for="account in accounts"
             :class="{
                 'disabled': _isDisabled(account),
@@ -93,19 +95,15 @@ export default class AccountList extends Vue {
         }
     }
 
-    private get accountContainerTag() {
-        return !this.editable || this.disabled ? 'a' : 'div';
-    }
-
     @Emit()
     // tslint:disable-next-line no-empty
     private accountChanged(address: string, label: string) {}
 
     private _isDisabled(account: AccountInfo | ContractInfo) {
-        return this.disabled
-            || this._isDisabledContract(account)
+        return this.disabled || (!this.editable
+            && (this._isDisabledContract(account)
             || this._isDisabledAccount(account)
-            || this._hasInsufficientBalance(account);
+            || this._hasInsufficientBalance(account)));
     }
 
     private _isDisabledContract(account: AccountInfo | ContractInfo) {
@@ -151,23 +149,6 @@ export default class AccountList extends Vue {
         text-decoration: none;
     }
 
-    .account-entry:not(.disabled)::after {
-        content: "";
-        position: absolute;
-        left: -0.625rem;
-        top: -0.625rem;
-        right: -0.625rem;
-        bottom: -0.625rem;
-        border: 0.25rem solid rgba(5, 130, 202, 0.5); /* Based on Nimiq Light Blue */
-        border-radius: 1rem;
-        opacity: 0;
-        pointer-events: none;
-    }
-
-    .account-entry:not(.disabled):focus::after {
-        opacity: 1;
-    }
-
     .account-entry >>> .identicon img {
         transform: scale(0.9);
         transition: transform .45s var(--nimiq-ease);
@@ -196,56 +177,68 @@ export default class AccountList extends Vue {
         outline: none;
     }
 
-    a.account-entry:not(.disabled):hover,
-    a.account-entry:not(.disabled):focus {
+    a.account-entry:focus::after {
+        content: "";
+        position: absolute;
+        left: -0.625rem;
+        top: -0.625rem;
+        right: -0.625rem;
+        bottom: -0.625rem;
+        border: 0.25rem solid rgba(5, 130, 202, 0.5); /* Based on Nimiq Light Blue */
+        border-radius: 1rem;
+        pointer-events: none;
+    }
+
+    a.account-entry:hover,
+    a.account-entry:focus {
         background-color: rgba(31, 35, 72, 0.06); /* Based on Nimiq Blue */
     }
 
-    a.account-entry:not(.disabled):hover >>> .identicon img,
-    a.account-entry:not(.disabled):focus >>> .identicon img {
+    a.account-entry:hover >>> .identicon img,
+    a.account-entry:focus >>> .identicon img {
         transform: scale(1);
     }
 
-    a.account-entry:not(.disabled):hover >>> .label,
-    a.account-entry:not(.disabled):hover >>> .balance,
-    a.account-entry:not(.disabled):focus >>> .label,
-    a.account-entry:not(.disabled):focus >>> .balance {
+    a.account-entry:hover >>> .label,
+    a.account-entry:hover >>> .balance,
+    a.account-entry:focus >>> .label,
+    a.account-entry:focus >>> .balance {
         opacity: 1;
     }
 
-    a.account-entry:not(.disabled):hover >>> .balance,
-    a.account-entry:not(.disabled):focus >>> .balance,
-    a.account-entry.has-tooltip >>> .balance {
+    a.account-entry:hover >>> .balance,
+    a.account-entry:focus >>> .balance,
+    .account-entry.has-tooltip >>> .balance {
         margin-right: 3rem; /* make space for caret or tooltip trigger */
     }
 
-    a.account-entry:not(.disabled):hover >>> .balance,
-    a.account-entry:not(.disabled):focus >>> .balance {
+    a.account-entry:hover >>> .balance,
+    a.account-entry:focus >>> .balance {
         color: var(--nimiq-green);
     }
 
-    a.account-entry:not(.disabled):hover .caret,
-    a.account-entry:not(.disabled):focus .caret {
+    a.account-entry:hover .caret,
+    a.account-entry:focus .caret {
         transform: translateX(0);
         opacity: 0.23;
     }
 
-    a.account-entry.disabled {
+    .account-entry.disabled {
         cursor: not-allowed;
     }
 
-    a.account-entry.disabled >>> .identicon,
-    a.account-entry.disabled >>> .label,
-    a.account-entry.disabled >>> .balance {
+    .account-entry.disabled >>> .identicon,
+    .account-entry.disabled >>> .label,
+    .account-entry.disabled >>> .balance {
         opacity: 0.2;
     }
 
-    a.account-entry.highlight-insufficient-balance >>> .balance {
+    .account-entry.highlight-insufficient-balance >>> .balance {
         color: var(--nimiq-red);
         opacity: 1;
     }
 
-    a.account-entry >>> .tooltip-box {
+    .account-entry >>> .tooltip-box {
         width: 23rem;
         cursor: default;
     }

--- a/src/components/AccountSelector.vue
+++ b/src/components/AccountSelector.vue
@@ -19,7 +19,8 @@
                     </Tooltip>
                 </div>
                 <AccountList
-                    :accounts="wallet | listAccountsAndContracts | sortAccountsAndContracts(minBalance, disableContracts)"
+                    :accounts="wallet | listAccountsAndContracts
+                        | sortAccountsAndContracts(minBalance, disableContracts, disabledAddresses)"
                     :disabledAddresses="disabledAddresses"
                     :walletId="wallet.id"
                     :minBalance="minBalance"
@@ -80,6 +81,7 @@ export interface WalletInfo {
             accounts: Array<AccountInfo|ContractInfo>,
             minBalance?: number,
             disableContracts?: boolean,
+            disabledAddresses?: string[],
         ): Array<AccountInfo|ContractInfo> => {
             if (!minBalance) return accounts;
 
@@ -89,6 +91,12 @@ export interface WalletInfo {
                 const bIsDisabledContract = disableContracts && !('path' in b && b.path);
                 if (aIsDisabledContract && !bIsDisabledContract) return 1;
                 if (!aIsDisabledContract && bIsDisabledContract) return -1;
+
+                // sort disabled addresses below other addresses
+                const aIsDisabledAddress = disabledAddresses && disabledAddresses.includes(a.userFriendlyAddress);
+                const bIsDisabledAddress = disabledAddresses && disabledAddresses.includes(b.userFriendlyAddress);
+                if (aIsDisabledAddress && !bIsDisabledAddress) return 1;
+                if (!aIsDisabledAddress && bIsDisabledAddress) return -1;
 
                 // sort accounts with insufficient funds below accounts with enough balance
                 if ((!a.balance || a.balance < minBalance) && b.balance && b.balance >= minBalance) return 1;

--- a/src/components/AccountSelector.vue
+++ b/src/components/AccountSelector.vue
@@ -11,6 +11,7 @@
                             ...tooltipProps,
                             styles: {
                                 width: '25.25rem',
+                                ...tooltipProps.styles,
                             },
                         }"
                     >
@@ -119,6 +120,9 @@ export default class AccountSelector extends Vue {
             right: 16,
             top: 32, // avoid that tooltips get affected by mask image
             bottom: 32,
+        },
+        styles: {
+            pointerEvents: 'none',
         },
     };
 

--- a/src/components/AccountSelector.vue
+++ b/src/components/AccountSelector.vue
@@ -1,19 +1,21 @@
 <template>
     <div class="account-selector">
-        <div class="container" :class="{'extra-spacing': wallets.length === 1}">
-            <div v-for="wallet in sortedWallets" :key="wallet.id"
-                :class="{
-                    'disabled-account': _isAccountDisabled(wallet),
-                    'highlighted-disabled-account': highlightedDisabledAccount === wallet,
-                }"
-            >
+        <div ref="container" class="container" :class="{'extra-spacing': wallets.length === 1}">
+            <div v-for="wallet in sortedWallets" :key="wallet.id">
                 <div v-if="wallets.length > 1 || _isAccountDisabled(wallet)" class="wallet-label">
-                    <div>
-                        <span class="nq-label">{{ wallet.label }}</span>
-                        <div v-if="_isAccountDisabled(wallet)" class="warning-disabled-account nq-label">
-                            (Incompatible with this operation)
-                        </div>
-                    </div>
+                    <div class="nq-label">{{ wallet.label }}</div>
+                    <Tooltip
+                        v-if="_isAccountDisabled(wallet)"
+                        :ref="`tooltip-${wallet.id}`"
+                        v-bind="{
+                            ...tooltipProps,
+                            styles: {
+                                width: '25.25rem',
+                            },
+                        }"
+                    >
+                        {{ _getAccountTypeName(wallet) }} Accounts cannot be used for this operation.
+                    </Tooltip>
                 </div>
                 <AccountList
                     :accounts="wallet | listAccountsAndContracts | sortAccountsAndContracts(minBalance, disableContracts)"
@@ -23,6 +25,7 @@
                     :decimals="decimals"
                     :disableContracts="disableContracts"
                     :disabled="_isAccountDisabled(wallet)"
+                    :tooltipProps="tooltipProps"
                     @account-selected="accountSelected"
                     @click.native="_accountClicked(wallet)"
                 />
@@ -38,6 +41,7 @@
 <script lang="ts">
 import {Component, Emit, Prop, Vue} from 'vue-property-decorator';
 import AccountList from './AccountList.vue';
+import Tooltip from './Tooltip.vue';
 
 // This is a reduced list of properties, for convenience
 export interface ContractInfo {
@@ -66,7 +70,7 @@ export interface WalletInfo {
 }
 
 @Component({
-    components: {AccountList},
+    components: {AccountList, Tooltip},
     filters: {
         listAccountsAndContracts(wallet: WalletInfo): Array<AccountInfo|ContractInfo> {
             return [ ...wallet.accounts.values(), ...wallet.contracts ];
@@ -105,8 +109,18 @@ export default class AccountSelector extends Vue {
     @Prop(Boolean) private disableLedgerAccounts?: boolean;
     @Prop({type: Boolean, default: true}) private allowLogin!: boolean;
 
-    private highlightedDisabledAccount: WalletInfo | null = null;
-    private highlightedDisabledAccountTimeout: number = -1;
+    private shownTooltip: Tooltip | null = null;
+    private hideTooltipTimeout: number = -1;
+    private tooltipProps: any = {
+        container: null, // set in mounted hook
+        preferredPosition: 'bottom right',
+        margin: {
+            left: 16,
+            right: 16,
+            top: 32, // avoid that tooltips get affected by mask image
+            bottom: 32,
+        },
+    };
 
     private get sortedWallets(): WalletInfo[] {
         return this.wallets.slice(0).sort((a: WalletInfo, b: WalletInfo): number => {
@@ -132,6 +146,12 @@ export default class AccountSelector extends Vue {
         });
     }
 
+    private mounted() {
+        this.tooltipProps.container = {
+            $el: this.$refs.container as HTMLElement,
+        };
+    }
+
     @Emit()
     // tslint:disable-next-line no-empty
     private accountSelected(walletId: string, address: string) {}
@@ -146,12 +166,31 @@ export default class AccountSelector extends Vue {
             || this.disableLedgerAccounts && account.type === 3 /* LEDGER */;
     }
 
-    private _accountClicked(account: WalletInfo) {
-        if (!this._isAccountDisabled(account)) return;
+    private _getAccountTypeName(account: WalletInfo): string {
+        switch (account.type) {
+            case 1: return 'Legacy';
+            case 2: return 'Keyguard';
+            case 3: return 'Ledger';
+            default: throw new Error(`Unknown account type ${account.type}`);
+        }
+    }
 
-        window.clearTimeout(this.highlightedDisabledAccountTimeout);
-        this.highlightedDisabledAccount = account;
-        this.highlightedDisabledAccountTimeout = window.setTimeout(() => this.highlightedDisabledAccount = null, 300);
+    private _accountClicked(account: WalletInfo) {
+        window.clearTimeout(this.hideTooltipTimeout);
+        const tooltip = this.$refs[`tooltip-${account.id}`]
+            ? (this.$refs[`tooltip-${account.id}`] as Tooltip[])[0]
+            : null;
+        if (this.shownTooltip && this.shownTooltip !== tooltip) {
+            this.shownTooltip.hide(/* force */ false);
+        }
+        if (tooltip) {
+            tooltip.show();
+            this.hideTooltipTimeout = window.setTimeout(() => {
+                tooltip.hide(/* force */ false);
+                this.shownTooltip = null;
+            }, 2000);
+        }
+        this.shownTooltip = tooltip;
     }
 }
 </script>
@@ -170,27 +209,12 @@ export default class AccountSelector extends Vue {
         padding-top: 0.5rem;
         padding-bottom: 4rem;
         flex-grow: 1;
-        mask-image: linear-gradient(0deg , rgba(255,255,255,0), rgba(255,255,255, 1) 4rem, rgba(255,255,255,1) calc(100% - 4rem), rgba(255,255,255,0));
+        mask-image: linear-gradient(0deg , rgba(255,255,255,0), rgba(255,255,255, 1) 4rem,
+            rgba(255,255,255,1) calc(100% - 4rem), rgba(255,255,255,0));
     }
 
     .container.extra-spacing {
         padding-top: 3rem;
-    }
-
-    .disabled-account > .wallet-label .nq-label {
-        opacity: .4;
-    }
-
-    .disabled-account .warning-disabled-account {
-        padding-top: .5rem;
-        text-transform: none;
-        line-height: 1.2;
-        transition: opacity .3s ease, color .3s ease;
-    }
-
-    .disabled-account.highlighted-disabled-account .warning-disabled-account {
-        color: var(--nimiq-red);
-        opacity: 1;
     }
 
     .wallet-label {
@@ -202,7 +226,10 @@ export default class AccountSelector extends Vue {
 
     .wallet-label .nq-label {
         margin: 0;
-        margin-right: 2rem;
+    }
+
+    .wallet-label .tooltip {
+        margin-left: 1rem;
     }
 
     .wallet-label::after {
@@ -210,6 +237,7 @@ export default class AccountSelector extends Vue {
         display: block;
         flex-grow: 1;
         height: 1px;
+        margin-left: 2rem;
         background: rgba(31, 35, 72, 0.1);
     }
 

--- a/src/components/PaymentInfoLine.vue
+++ b/src/components/PaymentInfoLine.vue
@@ -23,7 +23,7 @@
             :startTime="startTime"
             :endTime="endTime"
             :theme="theme"
-            :tooltipContainer="$parent"
+            :tooltipProps="{ container: $parent }"
         />
     </div>
 </template>

--- a/src/components/PaymentInfoLine.vue
+++ b/src/components/PaymentInfoLine.vue
@@ -17,7 +17,14 @@
             <ArrowRightSmallIcon/>
         </div>
         <Account :address="address" :image="shopLogoUrl" :label="originDomain" />
-        <Timer v-if="startTime && endTime" ref="timer" :startTime="startTime" :endTime="endTime" :theme="theme" />
+        <Timer
+            v-if="startTime && endTime"
+            ref="timer"
+            :startTime="startTime"
+            :endTime="endTime"
+            :theme="theme"
+            :tooltipContainer="$parent"
+        />
     </div>
 </template>
 

--- a/src/components/Timer.vue
+++ b/src/components/Timer.vue
@@ -1,8 +1,10 @@
 <template>
     <Tooltip class="timer"
-        preferredPosition="bottom right"
-        :container="tooltipContainer"
-        :theme="theme"
+        v-bind="{
+            preferredPosition: 'bottom right',
+            theme,
+            ...tooltipProps
+        }"
         @show="detailsShown = true"
         @hide="detailsShown = false"
         :class="{
@@ -117,7 +119,7 @@ class Timer extends Vue {
     })
     public strokeWidth!: number;
 
-    @Prop(Object) public tooltipContainer?: Vue | {$el: HTMLElement};
+    @Prop(Object) public tooltipProps?: object;
 
     public synchronize(referenceTime: number) {
         this.timeOffset = referenceTime - Date.now();

--- a/src/components/Timer.vue
+++ b/src/components/Timer.vue
@@ -1,44 +1,50 @@
 <template>
-    <div class="timer" tabindex="0"
-        @focus="detailsShown = true" @mouseenter="detailsShown = true"
-        @blur="detailsShown = false" @mouseleave="detailsShown = false"
+    <Tooltip class="timer"
+        preferredPosition="bottom right"
+        :container="tooltipContainer"
+        :theme="theme"
+        @show="detailsShown = true"
+        @hide="detailsShown = false"
         :class="{
             'time-shown': detailsShown || alwaysShowTime,
             'little-time-left': _progress >= .75,
             'inverse-theme': theme === constructor.Themes.INVERSE,
         }"
     >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26">
-            <circle ref="time-circle" class="time-circle" cx="50%" cy="50%" :r="radius.currentValue"
+        <template v-slot:trigger>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26">
+                <circle ref="time-circle" class="time-circle" cx="50%" cy="50%" :r="radius.currentValue"
                     :stroke-dasharray="`${_timeCircleInfo.length} ${_timeCircleInfo.gap}`"
                     :stroke-dashoffset="_timeCircleInfo.offset"
                     :stroke-width="_timeCircleInfo.strokeWidth"></circle>
-            <circle class="filler-circle" cx="50%" cy="50%" :r="radius.currentValue"
+                <circle class="filler-circle" cx="50%" cy="50%" :r="radius.currentValue"
                     :stroke-dasharray="`${_fillerCircleInfo.length} ${_fillerCircleInfo.gap}`"
                     :stroke-dashoffset="_fillerCircleInfo.offset"
                     :stroke-width="_fillerCircleInfo.strokeWidth"></circle>
 
-            <transition name="transition-fade">
-                <g v-if="!detailsShown && !alwaysShowTime" class="info-exclamation-icon">
-                    <rect x="12" y="9" width="2" height="2" rx="1" />
-                    <rect x="12" y="12.5" width="2" height="4.5" rx="1" />
-                </g>
-                <text v-else class="countdown" x="50%" y="50%">
-                    {{ _timeLeft | _toSimplifiedTime(false) }}
-                </text>
-            </transition>
-        </svg>
-        <transition>
-            <div v-if="detailsShown" class="tooltip">
+                <transition name="transition-fade">
+                    <g v-if="!detailsShown && !alwaysShowTime" class="info-exclamation-icon">
+                        <rect x="12" y="9" width="2" height="2" rx="1" />
+                        <rect x="12" y="12.5" width="2" height="4.5" rx="1" />
+                    </g>
+                    <text v-else class="countdown" x="50%" y="50%">
+                        {{ _timeLeft | _toSimplifiedTime(false) }}
+                    </text>
+                </transition>
+            </svg>
+        </template>
+        <template v-slot:default>
+            <div class="tooltip-content">
                 This offer expires in {{ _timeLeft | _toSimplifiedTime(true) }}.
             </div>
-        </transition>
-    </div>
+        </template>
+    </Tooltip>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Watch, Vue } from 'vue-property-decorator';
 import { Tweenable } from '@nimiq/utils';
+import Tooltip from './Tooltip.vue';
 
 interface CircleInfo {
     length: number;
@@ -78,6 +84,7 @@ function _toSimplifiedTime(millis: number, includeUnit: boolean = true): number 
 
 @Component({
     filters: { _toSimplifiedTime },
+    components: { Tooltip },
 })
 class Timer extends Vue {
     private static readonly REM_FACTOR = 8; // size of 1rem
@@ -109,6 +116,8 @@ class Timer extends Vue {
         default: 2,
     })
     public strokeWidth!: number;
+
+    @Prop(Object) public tooltipContainer?: Vue | {$el: HTMLElement};
 
     public synchronize(referenceTime: number) {
         this.timeOffset = referenceTime - Date.now();
@@ -256,8 +265,6 @@ export default Timer;
     .timer {
         width: 3.25rem;
         position: relative;
-        outline: none;
-        cursor: default;
     }
 
     /* for setting height automatically depending on width */
@@ -267,6 +274,7 @@ export default Timer;
         display: block;
     }
 
+    .tooltip >>> .trigger,
     svg {
         display: block;
         position: absolute;
@@ -274,6 +282,9 @@ export default Timer;
         top: 0;
         width: 100%;
         height: 100%;
+    }
+
+    svg {
         fill: none;
         stroke-linecap: round;
     }
@@ -357,32 +368,7 @@ export default Timer;
         opacity: 0 !important;
     }
 
-    .tooltip {
-        position: absolute;
-        top: calc(100% + 1rem);
-        right: calc(50% - 3rem);
-        width: 17rem;
-        height: 8rem;
-        padding: 2rem 1.25rem .875rem 1.5rem;
-        font-size: 1.75rem;
-        line-height: 1.5;
-        font-weight: 600;
-        color: white;
-        z-index: 1;
-        pointer-events: none;
-        background: var(--nimiq-blue-bg);
-        mask-image: url('data:image/svg+xml,<svg viewBox="0 0 136 63.9" xmlns="http://www.w3.org/2000/svg"><path d="M136 59.9a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4v-47a4 4 0 0 1 4-4h99a4 4 0 0 0 3.2-1.7l4.6-6.6c.6-.8 1.8-.8 2.4 0l4.6 6.6a4 4 0 0 0 3.3 1.7H132a4 4 0 0 1 4 4z" fill="white"/></svg>');
-        transition: opacity .3s var(--nimiq-ease), transform .3s var(--nimiq-ease);
-    }
-
-    .inverse-theme .tooltip {
-        color: var(--nimiq-blue);
-        background: white;
-    }
-
-    .tooltip.v-enter,
-    .tooltip.v-leave-to {
-        opacity: 0;
-        transform: translateY(-.5rem);
+    .tooltip-content {
+        width: 15rem;
     }
 </style>

--- a/src/components/Timer.vue
+++ b/src/components/Timer.vue
@@ -3,7 +3,12 @@
         v-bind="{
             preferredPosition: 'bottom right',
             theme,
-            ...tooltipProps
+            ...tooltipProps,
+            styles: {
+                width: '17.25rem',
+                pointerEvents: 'none',
+                ...(tooltipProps ? tooltipProps.styles : undefined),
+            },
         }"
         @show="detailsShown = true"
         @hide="detailsShown = false"
@@ -36,9 +41,7 @@
             </svg>
         </template>
         <template v-slot:default>
-            <div class="tooltip-content">
-                This offer expires in {{ _timeLeft | _toSimplifiedTime(true) }}.
-            </div>
+            This offer expires in {{ _timeLeft | _toSimplifiedTime(true) }}.
         </template>
     </Tooltip>
 </template>
@@ -368,9 +371,5 @@ export default Timer;
     .transition-fade-enter,
     .transition-fade-leave-to {
         opacity: 0 !important;
-    }
-
-    .tooltip-content {
-        width: 15rem;
     }
 </style>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -39,9 +39,15 @@ import { AlertTriangleIcon } from './Icons';
 
 @Component({ components: { AlertTriangleIcon }})
 class Tooltip extends Vue {
+    /**
+     * Container within which the tooltip should be positioned if possible.
+     */
     @Prop(Object) public container?: Vue | {$el: HTMLElement};
     @Prop(Boolean) public disabled?: boolean;
 
+    /**
+     * Preferred tooltip position as "[vertical] [horizontal]" or "[vertical]".
+     */
     @Prop({
         type: String,
         default: 'top right',
@@ -54,6 +60,10 @@ class Tooltip extends Vue {
         },
     }) public preferredPosition!: string;
 
+    /**
+     * Margin to maintain to container. If no container is set, this prop has no effect. For omitted values, the
+     * container's padding is used as margin.
+     */
     @Prop({
         type: Object,
         validator: (value: unknown) => typeof value === 'object'
@@ -62,10 +72,13 @@ class Tooltip extends Vue {
                     || Object.values(Tooltip.HorizontalPosition).includes(position as Tooltip.HorizontalPosition))),
     }) public margin?: Partial<Record<Tooltip.VerticalPosition | Tooltip.HorizontalPosition, number>>;
 
+    /**
+     * Sets the tooltip's width to the container's width minus margin. If no container is set, this prop has no effect.
+     */
     @Prop({
         type: Boolean,
         default: false,
-    }) public autoWidth!: boolean; // only relevant when using a container
+    }) public autoWidth!: boolean;
 
     @Prop({
         type: String,
@@ -74,6 +87,9 @@ class Tooltip extends Vue {
     })
     public theme!: Tooltip.Themes;
 
+    /**
+     * Styles to apply on the tooltip box without the need to use deep css selectors.
+     */
     @Prop(Object) public styles?: Partial<CSSStyleDeclaration>;
 
     /** @deprecated */

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -26,7 +26,7 @@
             <div ref="tooltipBox"
                 v-if="isShown"
                 class="tooltip-box"
-                :style="styles">
+                :style="tooltipBoxStyles">
                 <slot></slot>
             </div>
         </transition>
@@ -74,6 +74,8 @@ class Tooltip extends Vue {
     })
     public theme!: Tooltip.Themes;
 
+    @Prop(Object) public styles?: Partial<CSSStyleDeclaration>;
+
     /** @deprecated */
     @Prop(Object) public reference?: Vue | {$el: HTMLElement};
 
@@ -112,13 +114,14 @@ class Tooltip extends Vue {
         return this.container || this.reference;
     }
 
-    private get styles() {
+    private get tooltipBoxStyles() {
         // note that we let the browser calculate height automatically
         return {
+            ...this.styles,
             top: this.top + 'px',
             left: this.left + 'px',
-            width: this.effectiveContainer && this.autoWidth ? this.width + 'px' : undefined,
-            maxWidth: this.effectiveContainer ? this.maxWidth + 'px' : undefined,
+            width: this.effectiveContainer && this.autoWidth ? this.width + 'px' : (this.styles || {}).width,
+            maxWidth: this.effectiveContainer ? this.maxWidth + 'px' : (this.styles || {}).maxWidth,
         };
     }
 
@@ -358,10 +361,12 @@ export default Tooltip;
 
     .trigger {
         position: relative;
-        display: block;
+        display: inline-block;
+        vertical-align: bottom;
         text-decoration: none;
         outline: none;
         cursor: default;
+        color: inherit;
     }
 
     .trigger >>> svg {

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -117,7 +117,7 @@ storiesOf('Basic', module)
                 props: { preferredPosition: 'bottom right' },
                 style: { margin: '4px' },
                 scopedSlots: {
-                    trigger: () => createElement(icon, { style: { color: 'var(--nimiq-blue)' } }),
+                    trigger: () => createElement(icon),
                     default: () => name,
                 }
             }));
@@ -212,7 +212,8 @@ storiesOf('Basic', module)
         const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
         const theme = select('theme', Object.values(Tooltip.Themes), Tooltip.Themes.NORMAL);
-        const fontSize = number('Font size (rem)', 3);
+        const styles = object('styles (json)', {});
+        const fontSize = number('External font size (rem)', 3);
         return {
             data() {
                 return {
@@ -222,6 +223,7 @@ storiesOf('Basic', module)
                     autoWidth,
                     disabled,
                     theme,
+                    styles,
                     fontSize,
                     refsLoaded: false,
                     shown: false,
@@ -258,6 +260,7 @@ storiesOf('Basic', module)
                                         :autoWidth="autoWidth"
                                         :disabled="disabled"
                                         :theme="theme"
+                                        :styles="styles"
                                         :style="{ fontSize: fontSize + 'rem' }"
                                         @show="shown = true"
                                         @hide="shown = false">

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -114,7 +114,13 @@ storiesOf('Basic', module)
         functional: true,
         render: (createElement) => {
             const icons = Object.entries(Icons).map(([name, icon]) => createElement(Tooltip, {
-                props: { preferredPosition: 'bottom right' },
+                props: {
+                    container: { $el: document.body },
+                    preferredPosition: 'bottom right',
+                    styles: {
+                        pointerEvents: 'none',
+                    },
+                },
                 style: { margin: '4px' },
                 scopedSlots: {
                     trigger: () => createElement(icon),

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -208,6 +208,7 @@ storiesOf('Basic', module)
     .add('Tooltip', () => {
         const useContainer = boolean('Use container', true);
         const preferredPosition = text('preferredPosition', 'top right');
+        const margin = object('margin (json)', {});
         const autoWidth = boolean('autoWidth', false);
         const disabled = boolean('disabled', false);
         const theme = select('theme', Object.values(Tooltip.Themes), Tooltip.Themes.NORMAL);
@@ -217,6 +218,7 @@ storiesOf('Basic', module)
                 return {
                     useContainer,
                     preferredPosition,
+                    margin,
                     autoWidth,
                     disabled,
                     theme,
@@ -238,7 +240,7 @@ storiesOf('Basic', module)
             components: { SmallPage, PageHeader, PageBody, Tooltip, Account },
             template: windowTemplate`<SmallPage :class="{ 'nq-blue-bg': theme === 'inverse' }">
                             <PageHeader>Test</PageHeader>
-                            <PageBody ref="container" style="overflow-y: scroll; position:relative;">
+                            <PageBody ref="container" style="overflow-y: scroll; background: aliceblue">
                                 <div style="height:320px"></div>
                                 <div style="max-width: 100%; display: flex; align-items: center;">
                                     <button class="nq-button-s" :class="[theme]" @click="$refs.tooltip.show()">
@@ -252,6 +254,7 @@ storiesOf('Basic', module)
                                     <Tooltip ref="tooltip"
                                         :container="useContainer ? container : undefined"
                                         :preferredPosition="preferredPosition"
+                                        :margin="margin"
                                         :autoWidth="autoWidth"
                                         :disabled="disabled"
                                         :theme="theme"

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -310,6 +310,7 @@ storiesOf('Components', module)
         const disableContracts = boolean('disableContracts', false);
         const disabled = boolean('disabled', false);
         const disabledAddress = text('blacklist address', 'NQ33 DH76 PHUKJ41Q LX3A U4E0 M0BM QJH9 QQL1');
+        const tooltipProps = object('tooltipProps (json)', {});
         return {
             components: {AccountList},
             methods: {
@@ -348,11 +349,12 @@ storiesOf('Components', module)
                     editable,
                     disableContracts,
                     disabled,
+                    tooltipProps,
                 };
             },
             template: `<AccountList @account-selected="accountSelected" :accounts="accounts" walletId="helloworld1"
                 :minBalance="minBalance" :decimals="decimals" :editable="editable" :disableContracts="disableContracts"
-                :disabled="disabled" :disabledAddresses="[disabledAddress]" />`
+                :disabled="disabled" :disabledAddresses="[disabledAddress]" :tooltipProps="tooltipProps" />`
         };
     })
     .add('AccountSelector', () => {
@@ -1107,16 +1109,17 @@ storiesOf('Components', module)
             timerEnded: false,
             theme: select('theme', Object.values(Timer.Themes), Timer.Themes.NORMAL),
             alwaysShowTime: boolean('alwaysShowTime', true),
+            tooltipProps: object('tooltipProps (json)', {}),
         }),
         template: `
             <div>
                 <div :class="{ 'nq-blue-bg': theme === 'inverse' }" style="display: flex; align-items: center; padding: 7rem 3rem 10rem 12rem">
                     <Timer :startTime="startTime" :endTime="endTime" :theme="theme" :alwaysShowTime="alwaysShowTime"
-                        @end="timerEnded = true" style="margin: 2rem"/>
+                        :tooltipProps="tooltipProps" @end="timerEnded = true" style="margin: 2rem"/>
                     <Timer :startTime="startTime" :endTime="endTime" :theme="theme" :alwaysShowTime="alwaysShowTime"
-                        style="width: 10rem; margin: 2rem"/>
+                        :tooltipProps="tooltipProps" style="width: 10rem; margin: 2rem"/>
                     <Timer :startTime="startTime" :endTime="endTime" :theme="theme" :alwaysShowTime="alwaysShowTime"
-                        style="width: 20rem; margin: 2rem"/>
+                        :tooltipProps="tooltipProps" style="width: 20rem; margin: 2rem"/>
                 </div>
                 <div v-if="startTime" style="margin: 1rem 2rem">Timer {{ timerEnded ? 'ended' : 'running' }}</div>
                 <div style="display: flex; flex-wrap: wrap; max-width: 95rem;">

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -996,15 +996,15 @@ storiesOf('Components', module)
         const address = text('address', 'NQ07 0000 00000000 0000 0000 0000 0000 0000');
         const shopLogo = text('shopLogo', 'https://pbs.twimg.com/profile_images/1150268408287698945/x4f3ITmx_400x400.png');
         let startTime = number('startTime', Date.now());
-        let expires = number('expires (-1 for unset)', -1);
-        if (expires < 0) expires = null;
+        let endTime = number('endTime (-1 for unset)', -1);
+        if (endTime < 0) endTime = null;
 
         return {
             components: {PaymentInfoLine},
-            data: () => ({ cryptoAmount, fiatAmount, origin, address, shopLogo, startTime, expires, theme }),
+            data: () => ({ cryptoAmount, fiatAmount, origin, address, shopLogo, startTime, endTime, theme }),
             template: `<div style="max-width: 420px" :class="{ 'nq-blue-bg': theme === 'inverse' }">
                 <PaymentInfoLine :cryptoAmount="cryptoAmount" :fiatAmount="fiatAmount"
-                :origin="origin" :address="address" :shopLogoUrl="shopLogo" :startTime="startTime" :expires="expires"
+                :origin="origin" :address="address" :shopLogoUrl="shopLogo" :startTime="startTime" :endTime="endTime"
                 :theme="theme"/>
             </div>`,
         };


### PR DESCRIPTION
Refactor `Timer`, `AccountList` and `AccountSelector` components to use the `Tooltip` component.
Also extends `Tooltip` features by possibility to pass tooltip-box styles without the need for deep selectors and with possibility to provide custom margins to the tooltip container.
As always: see commit history for more details.
PR might be best reviewed with white-space changes disabled.