### PR TITLE
Fiat amount max relative deviation

### DIFF
--- a/src/components/Amount.vue
+++ b/src/components/Amount.vue
@@ -10,10 +10,18 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { FormattableNumber } from '@nimiq/utils';
 type BigInteger = import ('big-integer').BigInteger;
 
+export function amountValidator(value: unknown): boolean {
+    return typeof value === 'number' || typeof value === 'bigint'
+        || (value && value.constructor && value.constructor.name.endsWith('Integer'));
+}
+
 @Component
 export default class Amount extends Vue {
     // Amount in smallest unit
-    @Prop({type: [Number, Object]}) public amount!: number | BigInteger;
+    @Prop({
+        required: true,
+        validator: amountValidator,
+    }) public amount!: number | bigint | BigInteger;
     // If set takes precedence over minDecimals and maxDecimals
     @Prop(Number) public decimals?: number;
     @Prop({type: Number, default: 2}) public minDecimals!: number;

--- a/src/components/FiatAmount.vue
+++ b/src/components/FiatAmount.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { FormattableNumber } from '@nimiq/utils';
+import { FormattableNumber, toNonScientificNumberString } from '@nimiq/utils';
 
 @Component
 export default class FiatAmount extends Vue {
@@ -23,6 +23,12 @@ export default class FiatAmount extends Vue {
     public currency!: string;
 
     @Prop({
+        type: Number,
+        default: .1,
+    })
+    public maxRelativeDeviation!: number;
+
+    @Prop({
         type: String,
         default: navigator.language,
     })
@@ -30,18 +36,54 @@ export default class FiatAmount extends Vue {
 
     private get _currencyString() {
         const localeWithLatinNumbers = `${this.locale}-u-nu-latn`;
-        const formatted = this.amount.toLocaleString([localeWithLatinNumbers, 'en-US'], {
+        const formattingOptions = {
             style: 'currency',
             currency: this.currency,
             currencyDisplay: 'symbol',
             useGrouping: false,
-        });
-        const integerPart = formatted.match(/\d+/)![0]; // first match is the integer part
-        return formatted
+            minimumFractionDigits: undefined,
+        };
+        let formatted: string;
+        formatted = this.amount.toLocaleString([localeWithLatinNumbers, 'en-US'], formattingOptions)
             // Enforce a dot as decimal separator for consistency. Using capturing groups instead of
             // lookahead/lookbehind to avoid browser support limitations.
-            .replace(/(\d)\D(\d)/, '$1.$2')
-            .replace(integerPart, new FormattableNumber(integerPart).toString(true));
+            .replace(/(\d)\D(\d)/, '$1.$2');
+        const numberRegex = /(-)?\D*(\d+)(\.(\d+))?/;
+        const [, sign, integers, decimalsIncludingSeparator, defaultDecimals] = formatted.match(numberRegex);
+        const formattedNumber = `${sign || ''}${integers}${decimalsIncludingSeparator || ''}`;
+        const relativeDeviation = Math.abs((this.amount - Number.parseFloat(formattedNumber)) / this.amount);
+
+        if (relativeDeviation > this.maxRelativeDeviation) {
+            // determine how many decimals we have to use
+            let sampleString: string;
+            if (this.maxRelativeDeviation === 0) {
+                // have to use all decimals of the original number, therefore we measure the decimals from this.amount.
+                sampleString = toNonScientificNumberString(this.amount);
+            } else {
+                // Check which decimal changes when advancing in maxAllowedDeviation steps.
+                // Note that this might in some cases generate one digit more than required for the requested precision:
+                // For example 1.011 JPY for max error 0.001 will be rendered as 1.011 while 1.01 would be acceptable.
+                // This happens if the last required digit is <= the first significant digit.
+                const maxAllowedDeviation = this.maxRelativeDeviation * this.amount;
+                sampleString = maxAllowedDeviation.toLocaleString('en-US', { // note: renders as non-scientific number
+                    maximumSignificantDigits: 1,
+                });
+            }
+            const [, , , , sampleDecimals] = sampleString.match(numberRegex);
+            formattingOptions.minimumFractionDigits = Math.min(
+                20, // maximum allowed by toLocaleString
+                Math.max(
+                    sampleDecimals ? sampleDecimals.length : 0,
+                    defaultDecimals ? defaultDecimals.length : 0,
+                ),
+            );
+
+            formatted = this.amount.toLocaleString([localeWithLatinNumbers, 'en-US'], formattingOptions)
+                .replace(/(\d)\D(\d)/, '$1.$2');
+        }
+
+        // apply integer grouping
+        return formatted.replace(integers, new FormattableNumber(integers).toString(true));
     }
 }
 </script>

--- a/src/components/FiatAmount.vue
+++ b/src/components/FiatAmount.vue
@@ -6,10 +6,13 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { FormattableNumber, toNonScientificNumberString } from '@nimiq/utils';
+import { FormattableNumber } from '@nimiq/utils';
 
 @Component
 export default class FiatAmount extends Vue {
+    private static readonly NUMBER_REGEX = /(-)?\D*(\d+)(\.(\d+))?/;
+    private static readonly DECIMAL_SEPARATOR_REGEX = /(\d)\D(\d)/;
+
     @Prop({
         type: Number,
         required: true,
@@ -41,48 +44,30 @@ export default class FiatAmount extends Vue {
             currency: this.currency,
             currencyDisplay: 'symbol',
             useGrouping: false,
-            minimumFractionDigits: undefined,
+            minimumFractionDigits: undefined, // start with decimal count typical for this.currency, e.g. 2 for eur
         };
         let formatted: string;
-        formatted = this.amount.toLocaleString([localeWithLatinNumbers, 'en-US'], formattingOptions)
-            // Enforce a dot as decimal separator for consistency. Using capturing groups instead of
-            // lookahead/lookbehind to avoid browser support limitations.
-            .replace(/(\d)\D(\d)/, '$1.$2');
-        const numberRegex = /(-)?\D*(\d+)(\.(\d+))?/;
-        const [, sign, integers, decimalsIncludingSeparator, defaultDecimals] = formatted.match(numberRegex);
-        const formattedNumber = `${sign || ''}${integers}${decimalsIncludingSeparator || ''}`;
-        const relativeDeviation = Math.abs((this.amount - Number.parseFloat(formattedNumber)) / this.amount);
+        let integers: string;
+        let relativeDeviation: number;
 
-        if (relativeDeviation > this.maxRelativeDeviation) {
-            // determine how many decimals we have to use
-            let sampleString: string;
-            if (this.maxRelativeDeviation === 0) {
-                // have to use all decimals of the original number, therefore we measure the decimals from this.amount.
-                sampleString = toNonScientificNumberString(this.amount);
-            } else {
-                // Check which decimal changes when advancing in maxAllowedDeviation steps.
-                // Note that this might in some cases generate one digit more than required for the requested precision:
-                // For example 1.011 JPY for max error 0.001 will be rendered as 1.011 while 1.01 would be acceptable.
-                // This happens if the last required digit is <= the first significant digit.
-                const maxAllowedDeviation = this.maxRelativeDeviation * this.amount;
-                sampleString = maxAllowedDeviation.toLocaleString('en-US', { // note: renders as non-scientific number
-                    maximumSignificantDigits: 1,
-                });
-            }
-            const [, , , , sampleDecimals] = sampleString.match(numberRegex);
-            formattingOptions.minimumFractionDigits = Math.min(
-                20, // maximum allowed by toLocaleString
-                Math.max(
-                    sampleDecimals ? sampleDecimals.length : 0,
-                    defaultDecimals ? defaultDecimals.length : 0,
-                ),
-            );
-
+        do {
             formatted = this.amount.toLocaleString([localeWithLatinNumbers, 'en-US'], formattingOptions)
-                .replace(/(\d)\D(\d)/, '$1.$2');
-        }
+                // Enforce a dot as decimal separator for consistency and parseFloat. Using capturing groups instead of
+                // lookahead/lookbehind to avoid browser support limitations.
+                .replace(FiatAmount.DECIMAL_SEPARATOR_REGEX, '$1.$2');
+            const regexMatch = formatted.match(FiatAmount.NUMBER_REGEX)!;
+            const [/* full match */, sign, /* integers */, decimalsIncludingSeparator, decimals] = regexMatch;
+            integers = regexMatch[2];
+            const formattedNumber = `${sign || ''}${integers}${decimalsIncludingSeparator || ''}`;
+            relativeDeviation = Math.abs((this.amount - Number.parseFloat(formattedNumber)) / this.amount);
+
+            formattingOptions.minimumFractionDigits = decimals ? decimals.length + 1 : 1;
+        } while (relativeDeviation > this.maxRelativeDeviation
+            && formattingOptions.minimumFractionDigits <= 20 // maximum allowed value for minimumFractionDigits
+        );
 
         // apply integer grouping
+        if (integers.length <= 4) return formatted;
         return formatted.replace(integers, new FormattableNumber(integers).toString(true));
     }
 }

--- a/src/components/PaymentInfoLine.vue
+++ b/src/components/PaymentInfoLine.vue
@@ -35,7 +35,7 @@ type BigInteger = import ('big-integer').BigInteger;
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import Account from './Account.vue';
 import Timer from './Timer.vue';
-import Amount from './Amount.vue';
+import Amount, { amountValidator } from './Amount.vue';
 import FiatAmount from './FiatAmount.vue';
 import { ArrowRightSmallIcon } from './Icons';
 
@@ -52,8 +52,7 @@ interface FiatAmountInfo {
 
 function cryptoAmountInfoValidator(value: any) {
     return 'amount' in value && 'currency' in value && 'decimals' in value
-        && (typeof value.amount === 'number' || typeof value.amount === 'bigint'
-            || (value.amount && value.amount.constructor && value.amount.constructor.name.endsWith('Integer')))
+        && amountValidator(value.amount)
         && typeof value.currency === 'string'
         && typeof value.decimals === 'number' && Number.isInteger(value.decimals);
 }

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -101,12 +101,14 @@ storiesOf('Basic', module)
     .add('FiatAmount', () => {
         const amount = number('amount', 12345.67);
         const currency = text('currency', 'eur');
+        const maxRelativeDeviation = number('maxRelativeDeviation', .1);
         const locale = text('locale', navigator.language);
 
         return {
             components: {FiatAmount},
-            data: () => ({ amount, currency, locale }),
-            template: `<FiatAmount :amount="amount" :currency="currency" :locale="locale" />`,
+            data: () => ({ amount, currency, maxRelativeDeviation, locale }),
+            template: `<FiatAmount :amount="amount" :currency="currency" :maxRelativeDeviation="maxRelativeDeviation"
+                :locale="locale" />`,
         };
     })
     .add('Icons', () => ({


### PR DESCRIPTION
Add support for setting a maximum allowed rounding error for fiat amounts.
This can be used to avoid that very small values get rendered as 0.
By default, a deviation of 10% is allowed. Feel free to suggest an alternative default value or a different prop name.

Also contains a little change in the (crypto) Amount component which lets it accept native bigint values.