### PR TITLE
Use bundled Iqons SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vue-property-decorator": "^8.4.0"
   },
   "devDependencies": {
-    "@nimiq/iqons": "^1.5.2",
+    "@nimiq/iqons": "^1.6.0",
     "@nimiq/utils": "^0.4.6",
     "@storybook/addon-actions": "^4.0.0-alpha.14",
     "@storybook/addon-knobs": "^4.0.0-alpha.14",

--- a/src/components/Identicon.vue
+++ b/src/components/Identicon.vue
@@ -7,19 +7,7 @@
 <script lang="ts">
 import {Component, Prop, Watch, Vue} from 'vue-property-decorator';
 import { ValidationUtils } from '@nimiq/utils';
-import Iqons from '@nimiq/iqons/dist/iqons.min.js';
-import IqonsSvg from '@nimiq/iqons/dist/iqons.min.svg';
-
-// Detect Iqons.svgPath
-// @ts-ignore
-if (self.NIMIQ_IQONS_SVG_PATH) Iqons.svgPath = self.NIMIQ_IQONS_SVG_PATH;
-else {
-    if (IqonsSvg[0] === '"') {
-        Iqons.svgPath = IqonsSvg.substring(1, IqonsSvg.length - 1);
-    } else {
-        Iqons.svgPath = IqonsSvg;
-    }
-}
+import Iqons from '@nimiq/iqons/dist/iqons.bundle.min.js';
 
 @Component
 export default class Identicon extends Vue {

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,10 +953,10 @@
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-"@nimiq/iqons@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.5.2.tgz#e5a104c99472c948be7cb82049ece19c4eeb96c9"
-  integrity sha512-K/6Kq9UoiwM3OeLwUhnGC78MRbe3wNyb+gk8jRC18QovM8I3wDCPxb8x8688/vx/8W9Fp8oNVlcnABdfKT92lw==
+"@nimiq/iqons@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.6.0.tgz#29829c57f1fbdf53f228146162579db4602017db"
+  integrity sha512-M1g/rFVmOoucgIPvb5cxOPz1GVUslBj5wz1YYZbLVS9FP4FrWoKUlnd3gQd4bfl4DIz3wT6QgEnI1gUgQ/QKQQ==
   dependencies:
     dom-parser "^0.1.5"
 


### PR DESCRIPTION
I manually shrinked all Iqons source SVGs to be their minimal size. The new iqons.min.svg is now 88kb (was 110kb before). The _bundled_ SVG is even smaller, because [I am using find-replace for larger string portions in the build step, which get reversed when the file is loaded](https://github.com/nimiq/iqons/commit/3bfc3aa81b5193bfc983d30b9ef215766d61a1c1). Thus the bundled Iqons lib is only 87kb (thats _including_ the Iqons source code!).

I suggest to use the bundled Iqons by default, which removes the need to always load the Iqons SVG separately in projects (no more need to remember and configure the file-loader for the Iqons SVG).

The vue-component bundle gets bigger this way, but therefore no additional request for a _bigger_ separate svg sprite is required.

What do you think?