### PR TITLE
Copyable updates

### DIFF
--- a/src/components/AccountDetails.vue
+++ b/src/components/AccountDetails.vue
@@ -4,9 +4,7 @@
         <Account layout="column" :address="address" :image="image" :label="label !== address ? label : ''"
              :walletLabel="walletLabel" :balance="balance" :editable="editable" :placeholder="placeholder"
              @changed="changed" ref="account"/>
-        <Copyable :text="address">
-            <AddressDisplay :address="address"/>
-        </Copyable>
+        <AddressDisplay :address="address" copyable />
     </div>
 </template>
 
@@ -15,10 +13,9 @@ import { Component, Prop, Emit, Vue } from 'vue-property-decorator';
 import Account from './Account.vue';
 import Amount from './Amount.vue';
 import AddressDisplay from './AddressDisplay.vue';
-import Copyable from './Copyable.vue';
 import CloseButton from './CloseButton.vue';
 
-@Component({components: {Account, Amount, AddressDisplay, Copyable, CloseButton}})
+@Component({components: {Account, Amount, AddressDisplay, CloseButton}})
 export default class AccountDetails extends Vue {
     @Prop(String) private address!: string;
     @Prop(String) private image?: string;
@@ -97,7 +94,7 @@ export default class AccountDetails extends Vue {
         margin-top: 3rem;
     }
 
-    .copyable {
+    .address-display {
         margin-top: 3rem;
         margin-bottom: 1.5rem;
     }

--- a/src/components/AddressDisplay.vue
+++ b/src/components/AddressDisplay.vue
@@ -1,19 +1,28 @@
 <template>
-    <div class="address-display">
+    <component :is="copyable ? 'Copyable' : 'div'" :text="chunks.join(' ').toUpperCase()" class="address-display">
         <span v-for="(chunk, index) in chunks" class="chunk" :key="chunk + index">{{ chunk }}<span class="space">&nbsp;</span></span>
-    </div>
+    </component>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
+import Copyable from './Copyable.vue';
 
-@Component
+@Component({ components: {Copyable} })
 export default class AddressDisplay extends Vue {
-    @Prop(String) private address!: string;
+    @Prop({
+        type: String,
+        required: true,
+    }) private address!: string;
+
+    @Prop({
+        type: Boolean,
+        default: false,
+    }) private copyable!: boolean;
 
     private get chunks(): string[] {
         if (!this.address) return new Array(9).fill('-');
-        return this.address.replace(/[\+ ]/g, '').match(/.{4}/g)!;
+        return this.address.replace(/[+ ]/g, '').match(/.{4}/g)!;
     }
 }
 </script>
@@ -22,12 +31,19 @@ export default class AddressDisplay extends Vue {
     .address-display {
         width: 100%;
         max-width: 28.25rem;
+        box-sizing: content-box;
         font-family: 'Fira Mono', monospace;
-        opacity: 0.5;
+        color: rgba(31, 35, 72, .5); /* nimiq-blue with .5 opacity */
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
         font-size: 3rem;
+    }
+
+    .address-display.copyable:hover,
+    .address-display.copyable:focus,
+    .address-display.copyable.copied {
+        font-weight: 500;
     }
 
     .chunk {

--- a/src/components/Copyable.vue
+++ b/src/components/Copyable.vue
@@ -2,7 +2,7 @@
     <div class="copyable" :class="{ copied }" @click="copy" tabindex="0">
         <div class="background"></div>
         <slot></slot>
-        <div class="tooltip">{{ $t('Copied') }}</div>
+        <div class="tooltip" ref="tooltip">{{ $t('Copied') }}</div>
     </div>
 </template>
 
@@ -33,7 +33,11 @@ export default class Copyable extends Mixins(I18nMixin) {
     private _copiedResetTimeout: number | null = null;
 
     public copy() {
-        const text = this.text || (this.$el as HTMLElement).innerText;
+        let text = this.text;
+        if (!text) {
+            const copiedLabel = (this.$refs.tooltip as HTMLElement).textContent;
+            text = (this.$el as HTMLElement).innerText.replace(new RegExp(`\\s*${copiedLabel}$`), '');
+        }
         Clipboard.copy(text);
 
         window.clearTimeout(this._copiedResetTimeout!);

--- a/src/components/Copyable.vue
+++ b/src/components/Copyable.vue
@@ -79,6 +79,7 @@ export default class Copyable extends Mixins(I18nMixin) {
     .copyable:focus,
     .copyable.copied {
         color: var(--nimiq-light-blue) !important;
+        outline: none;
     }
 
     .background {

--- a/src/stories/index.stories.js
+++ b/src/stories/index.stories.js
@@ -454,14 +454,13 @@ storiesOf('Components', module)
         };
     })
     .add('AddressDisplay', () => {
+        const address = text('address', 'NQ12 3ASK LDJF ALKS DJFA KLSD FJAK LSDJ FDRE');
+        const copyable = boolean('copyable', false);
         return {
-            data() {
-                return {
-                    address: 'NQ12 3ASK LDJF ALKS DJFA KLSD FJAK LSDJ FDRE',
-                };
-            },
+            data: () => ({ address, copyable }),
             components: {AddressDisplay},
-            template: `<AddressDisplay :address="address"/>`,
+            template: `<AddressDisplay :address="address" :copyable="copyable"
+                style="margin-top: 7rem; margin-left: 2rem;" />`,
         };
     })
     .add('AddressInput', () => {
@@ -633,19 +632,6 @@ storiesOf('Components', module)
                     Click me to trigger a copy via code
                 </button>
             </div>
-        `,
-    }))
-    .add('Copyable Address', () => ({
-        data() {
-            return {
-                address: 'NQ12 3ASK LDJF ALKS DJFA KLSD FJAK LSDJ FDRE',
-            };
-        },
-        components: { Copyable, AddressDisplay },
-        template: `
-            <Copyable style="margin-top: 7rem; margin-left: 2rem; display: inline-block;">
-                <AddressDisplay :address="address"/>
-            </Copyable>
         `,
     }))
     .add('CopyableField', () => {


### PR DESCRIPTION
- Fix `Copyable` tooltip text getting copied
- Fix `Copyable` focus styles
- Add `Copyable` feature directly to `AddressDisplay` with correct / fixed style
- Use `AddressDisplay` in `AccountDetails` with new `copyable` prop, without additional `Copyable`.