### PR TITLE
Configurable asset public path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ const plugins = [
         },
         // for the identicons
         {
-            from: 'node_modules/@nimiq/vue-components/dist/img',
-            to: 'img/',
+            from: 'node_modules/@nimiq/vue-components/dist/iqons.min.*.svg',
+            to: './',
+            flatten: true,
         },
         // for the QR scanner
         {
-            from: 'node_modules/@nimiq/vue-components/dist/qr-scanner-worker.min.js',
+            from: 'node_modules/@nimiq/vue-components/dist/qr-scanner-worker.min.*.js',
             to: './',
             flatten: true,
         },

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ setAssetPublicPath('/my-path/');
 
 // Useful for projects setup via vue-cli to apply the app's public path to the vue-component assets
 setAssetPublicPath(process.env.BASE_URL);
+
+// You can also specify a separate folder for image assets
+setAssetPublicPath('/js', '/img');
 ```
 
 ## Updating

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ yarn add github:nimiq/vue-components#build/master
 This will install the complete component collection. To install only a subset for reduced bundle size, see section
 [Advanced setup](#advanced-setup).
 
-The components offer translations via lazy-loaded language files. If you want to support other languages than
-English, you have to copy these language files over to your project. If your project has been created with the
+Some components require additional lazy-loaded assets which have to be copied over to your project. Specifically, these
+are translation files (if you want to support other languages than English), the Identicon svg asset and the QR scanner
+worker.
+
+If your project has been created with the
 [vue-cli](https://cli.vuejs.org/) / gets bundled via [webpack](https://webpack.js.org/), this can be conveniently done
 with the [CopyWebpackPlugin](https://webpack.js.org/plugins/copy-webpack-plugin/):
 
@@ -23,9 +26,10 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const plugins = [
     new CopyWebpackPlugin([
+        // for translation files
         {
             from: 'node_modules/@nimiq/vue-components/dist/NimiqVueComponents.umd.min.lang-*.js',
-            to: './js',
+            to: './',
             flatten: true,
             transformPath(path) {
                 // If you are bundling a non-minified build of the components (for later minification in your build
@@ -33,6 +37,17 @@ const plugins = [
                 // to load the minified files instead, so we rename them.
                 return path.replace('.min', '');
             },
+        },
+        // for the identicons
+        {
+            from: 'node_modules/@nimiq/vue-components/dist/img',
+            to: 'img/',
+        },
+        // for the QR scanner
+        {
+            from: 'node_modules/@nimiq/vue-components/dist/qr-scanner-worker.min.js',
+            to: './',
+            flatten: true,
         },
     ]),
     ...
@@ -51,6 +66,18 @@ module.exports = {
     },
     ...
 };
+```
+
+By default, these assets are resolved relatively to the importing script's location (the importing script's
+currentScript src) as base path. Alternatively, you can also specify a custom path:
+
+```js
+import { setAssetPublicPath } from '@nimiq/vue-components';
+
+setAssetPublicPath('/my-path/');
+
+// Useful for projects setup via vue-cli to apply the app's public path to the vue-component assets
+setAssetPublicPath(process.env.BASE_URL);
 ```
 
 ## Updating

--- a/src/components/Identicon.vue
+++ b/src/components/Identicon.vue
@@ -38,9 +38,14 @@ export default class Identicon extends Vue {
                 // of a normal import use a dynamic import at usage time to give apps the opportunity to adapt the base
                 // path via setAssetPublicPath before the path is being determined. Using webpackMode: 'eager' to avoid
                 // creating an additional chunk and to let the import resolve immediately.
-                ({ default: Iqons.svgPath } = await import(
+                let { default: svgPath } = await import(
                     /* webpackMode: 'eager' */
-                    '!!file-loader?name=[name].[hash:8].[ext]!@nimiq/iqons/dist/iqons.min.svg'));
+                    '!!file-loader?name=[name].[hash:8].[ext]!@nimiq/iqons/dist/iqons.min.svg');
+                if (typeof self.NIMIQ_VUE_COMPONENTS_IMAGE_ASSET_PATH === 'string') {
+                    // @ts-ignore TS2304: Cannot find name '__webpack_public_path__'.
+                    svgPath = svgPath.replace(__webpack_public_path__, self.NIMIQ_VUE_COMPONENTS_IMAGE_ASSET_PATH);
+                }
+                Iqons.svgPath = svgPath;
             }
 
             this.dataUrl = await Iqons.toDataUrl(Identicon.formatAddress(this.address));

--- a/src/components/Identicon.vue
+++ b/src/components/Identicon.vue
@@ -40,7 +40,7 @@ export default class Identicon extends Vue {
                 // creating an additional chunk and to let the import resolve immediately.
                 ({ default: Iqons.svgPath } = await import(
                     /* webpackMode: 'eager' */
-                    '@nimiq/iqons/dist/iqons.min.svg'));
+                    '!!file-loader?name=[name].[hash:8].[ext]!@nimiq/iqons/dist/iqons.min.svg'));
             }
 
             this.dataUrl = await Iqons.toDataUrl(Identicon.formatAddress(this.address));

--- a/src/components/QrScanner.vue
+++ b/src/components/QrScanner.vue
@@ -88,7 +88,7 @@ class QrScanner extends Mixins(I18nMixin) {
         // an additional chunk and to let the import resolve immediately.
         ({ default: QrScannerLib.WORKER_PATH } = await import(
             /* webpackMode: 'eager' */
-            '!!file-loader?name=[name].[ext]!../../node_modules/qr-scanner/qr-scanner-worker.min.js'));
+            '!!file-loader?name=[name].[hash:8].[ext]!../../node_modules/qr-scanner/qr-scanner-worker.min.js'));
 
         this.repositionOverlay = this.repositionOverlay.bind(this);
         const $video = this.$refs.video as HTMLVideoElement;

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,15 +36,27 @@ export * from './components/Icons';
 
 export { default as I18nMixin } from './i18n/I18nMixin';
 
+declare global {
+    interface Window {
+        NIMIQ_VUE_COMPONENTS_IMAGE_ASSET_PATH?: string;
+    }
+}
+
 /**
  * Set a specific public path / base path (see https://webpack.js.org/guides/public-path/) from where assets like
  * translation files, identicons or the qr scanner worker should be loaded. By default, this is the path from where
  * the importing script is loaded, derived from the importing script's currentScript src.
+ *
+ * Optionally, you can define a different path for image assets.
  */
-export function setAssetPublicPath(path: string) {
+export function setAssetPublicPath(path: string, imageAssetsPath?: string) {
     // See https://webpack.js.org/guides/public-path/#on-the-fly.
     // Note that the default for build target "lib" is set via @vue/cli-service/lib/commands/build/setPublicPath.js and
     // can not be overwritten via publicPath in vue.config.js.
     // @ts-ignore
     __webpack_public_path__ = `${path}${!path.endsWith('/') ? '/' : ''}`;
+
+    if (typeof imageAssetsPath === 'string') {
+        self.NIMIQ_VUE_COMPONENTS_IMAGE_ASSET_PATH = `${imageAssetsPath}${!imageAssetsPath.endsWith('/') ? '/' : ''}`;
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,3 +35,16 @@ export { default as Wallet } from './components/Wallet.vue';
 export * from './components/Icons';
 
 export { default as I18nMixin } from './i18n/I18nMixin';
+
+/**
+ * Set a specific public path / base path (see https://webpack.js.org/guides/public-path/) from where assets like
+ * translation files, identicons or the qr scanner worker should be loaded. By default, this is the path from where
+ * the importing script is loaded, derived from the importing script's currentScript src.
+ */
+export function setAssetPublicPath(path: string) {
+    // See https://webpack.js.org/guides/public-path/#on-the-fly.
+    // Note that the default for build target "lib" is set via @vue/cli-service/lib/commands/build/setPublicPath.js and
+    // can not be overwritten via publicPath in vue.config.js.
+    // @ts-ignore
+    __webpack_public_path__ = `${path}${!path.endsWith('/') ? '/' : ''}`;
+}


### PR DESCRIPTION
- Allow setting a custom path for assets like translations, the qr scanner worker and the identicon svg. By default, these assets are resolved relatively to the importing script's location (the importing script's currentScript src) as base path. This default behavior lead to issues in the hub for sub paths like `/sign-transaction`.
- In the storybook, the identicon svg is now also loaded as separate asset instead of as an inlined data-url for consistency and removal of extra handling of the data url.
- qr worker file name now includes a file hash to avoid that an outdated, cached version might be used on updates.
- Also improves on the documentation.

The changes have been tested in the storybook, app development builds and production builds.
See here for changes in hub and wallt which will be merged when this PR is merged:
- https://github.com/nimiq/wallet/compare/daniel/configurable-components-asset-public-path
- https://github.com/nimiq/hub/compare/daniel/configurable-components-asset-public-path